### PR TITLE
add pull_init script for initial pull

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,16 +6,13 @@ build :
 	scripts/install_py_extensions.bash
 	scripts/repair.sh
 
-
 doc :
 	python3 scripts/build-complete-doc.py
-
 
 doc-meta :
 	python3 scripts/build-meta-doc.py
 
-
-install: pull-all 
+install: pull-init
 	scripts/install.pl
 
 update: pull-all
@@ -26,8 +23,10 @@ pull-all:
 	scripts/pull_all.sh
 	scripts/pull_files.bash
 
+pull-init:
+	git pull
+	scripts/pull_init.sh
+	scripts/pull_files.bash
 
 vision-files:
 	scripts/pull_files.bash
-
-

--- a/scripts/pull_all.sh
+++ b/scripts/pull_all.sh
@@ -1,8 +1,2 @@
 #!/bin/sh
-
-{
-    git submodule update --recursive --remote --init &&
-    git submodule foreach -q --recursive 'branch="$(git config -f $toplevel/.gitmodules submodule.$name.branch)"; [ "$branch" = "" ] && git checkout master || git checkout $branch' &&
-    git submodule sync &&
-    git submodule foreach git pull
-} || { echo -e "\033[91m\033[1m########## Pull failed! ##########\033[0m" && exit 1; }
+git submodule foreach git pull

--- a/scripts/pull_init.sh
+++ b/scripts/pull_init.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+{
+    git submodule update --recursive --remote --init &&
+    git submodule foreach -q --recursive 'branch="$(git config -f $toplevel/.gitmodules submodule.$name.branch)"; [ "$branch" = "" ] && git checkout master || git checkout $branch' &&
+    git submodule sync &&
+    git submodule foreach git pull
+} || { echo -e "\033[91m\033[1m########## Pull failed! ##########\033[0m" && exit 1; }


### PR DESCRIPTION
Currently, the pull_all script does, what should actually only be done when the repository is initially cloned: the submodules are initialized and checked out to the default branch. The expected behavior of a pull_all script is a `git pull` in every submodule. Thereby, no changes get lost due to checkout and the custom branches are kept. 

This pull request changes the pull_all script to actually pull every branch and a pull_init script is added for the initial pull. The Makefile was adapted accordingly.