### PR TITLE
sync includes: add bitbots_docs

### DIFF
--- a/sync_includes_davros.yaml
+++ b/sync_includes_davros.yaml
@@ -7,6 +7,7 @@ include:
         - bitbots_cm730 #?
     - bitbots_misc:
         - bitbots_bringup
+        - bitbots_docs
     - bitbots_vision:
         - bitbots_imageloader
         - bitbots_vision

--- a/sync_includes_wolfgang_jetson.yaml
+++ b/sync_includes_wolfgang_jetson.yaml
@@ -2,6 +2,7 @@ include:
     - basler_drivers
     - bitbots_misc:
         - bitbots_bringup
+        - bitbots_docs
     - bitbots_msgs
     - bitbots_vision:
         - bitbots_vision

--- a/sync_includes_wolfgang_nuc.yaml
+++ b/sync_includes_wolfgang_nuc.yaml
@@ -9,6 +9,7 @@ include:
         - bitbots_ros_control
     - bitbots_misc:
         - bitbots_bringup
+        - bitbots_docs
         - bitbots_teleop
         - system_monitor
     - bitbots_motion:

--- a/sync_includes_wolfgang_odroid.yaml
+++ b/sync_includes_wolfgang_odroid.yaml
@@ -9,6 +9,7 @@ include:
         - bitbots_ros_control
     - bitbots_misc:
         - bitbots_bringup
+        - bitbots_docs
         - bitbots_teleop
     - bitbots_motion:
         - bitbots_animation_server


### PR DESCRIPTION
This is necessary because it is find_packaged in several packages that build the documentation.