### PR TITLE
Add geometry2 to jetson sync includes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -75,3 +75,7 @@
 	path = lib/vision_opencv
 	url = git@github.com:ros-perception/vision_opencv.git
     branch = melodic
+[submodule "lib/geometry2"]
+	path = lib/geometry2
+	url = https://github.com/ros/geometry2
+    branch = melodic-devel

--- a/scripts/pull_all.sh
+++ b/scripts/pull_all.sh
@@ -5,6 +5,8 @@ git submodule update --init lib/dwa_local_planner
 git -C lib/dwa_local_planner checkout master
 git submodule update --init lib/vision_opencv
 git -C lib/vision_opencv checkout melodic
+git submodule update --init lib/geometry2
+git -C lib/geometry2 checkout melodic-devel
 git submodule foreach git pull
 if [[ -d basler_drivers ]]; then
     git -C basler_drivers pull

--- a/sync_includes_wolfgang_jetson.yaml
+++ b/sync_includes_wolfgang_jetson.yaml
@@ -10,6 +10,7 @@ include:
         - white_balancer
     - humanoid_league_msgs
     - lib:
+        - geometry2
         - vision_opencv
     - wolves_image_provider
     - scripts


### PR DESCRIPTION
For our vision, we need python3, but the official apt repositories provide python2 builds of the ROS packages. Therefore, we need to build the tf2 packages manually on the jetson. This PR adds the geometry2 packages as submodule to our lib folder and pushes it to the jetson on sync. To initially pull the repository with `make pull-all`, it is also added to the corresponding script.