### PR TITLE
robot_compile: increase verbosity of rsync

### DIFF
--- a/scripts/robot_compile.py
+++ b/scripts/robot_compile.py
@@ -301,7 +301,7 @@ def sync(target, package='', pre_clean=False):
         "rsync",
         "--checksum",
         "--archive",
-        "-v" if LOGLEVEL.current >= LOGLEVEL.DEBUG else "",
+        "-v" if LOGLEVEL.current >= LOGLEVEL.INFO else "",
         "--delete",
     ]
     cmd.extend(get_includes_from_file(target.sync_includes_file, package))


### PR DESCRIPTION
## Proposed changes
This pull request increases the verbosity of rsync in the robot compile script. This results in the synced files being printed on the screen. I suggest this change because the information which files have been changed and are therefore synced is roughly the same verbosity as the package build information which is currently on INFO and should be display because it makes errors in file syncing easier to detect.

## Necessary checks
- [ ] Update package version
- [ ] Run linters
- [ ] Run `catkin build`
- [ ] Write documentation
- [x] Test on your machine
- [x] Test on the robot

