### PR TITLE
direct_robot: return only first matching ip address

### DIFF
--- a/scripts/direct_robot.sh
+++ b/scripts/direct_robot.sh
@@ -7,7 +7,7 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
    exit 1
 fi
 
-_IP=$(ip a | grep 'inet 192\.168\.[0123]\.' | awk '{print $2}' | cut -d '/' -f 1)
+_IP=$(ip a | grep -m 1 'inet 192\.168\.[0123]\.' | awk '{print $2}' | cut -d '/' -f 1)
 
 if [[ -z $_IP ]]; then
     echo "No network available"


### PR DESCRIPTION
## Proposed changes
Currently when connected to wifi and ethernet, the direct_robot script returns both ip addresses. This fixes the problem by only returning the first match.

## Necessary checks
- [ ] Update package version
- [ ] Run linters
- [ ] Run `catkin build`
- [ ] Write documentation
- [x] Test on your machine
- [ ] Test on the robot

