### PR TITLE
Do not sync the wolves image provider to the jetsons

### DIFF
--- a/sync_includes_wolfgang_jetson.yaml
+++ b/sync_includes_wolfgang_jetson.yaml
@@ -13,7 +13,6 @@ include:
     - lib:
         - geometry2
         - vision_opencv
-    - wolves_image_provider
     - scripts
     - lib:
         - vision_opencv


### PR DESCRIPTION
## Proposed changes
The Wolves Image Provider is no longer necessary with the Basler camera we are currently using.

## Necessary checks
- [ ] Update package version
- [ ] Run linters
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Test on your machine
- [x] Test on the robot

