### PR TITLE
add dependency for python3, update nuc includes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -79,3 +79,6 @@
 [submodule "lib/particle_filter"]
 	path = lib/particle_filter
 	url = git@github.com:bit-bots/particle_filter.git
+[submodule "lib/orocos_kinematics_dynamics"]
+	path = lib/orocos_kinematics_dynamics
+	url = https://github.com/orocos/orocos_kinematics_dynamics.git

--- a/sync_includes_wolfgang_nuc.yaml
+++ b/sync_includes_wolfgang_nuc.yaml
@@ -43,7 +43,10 @@ include:
         - DynamixelSDK
         - dynamixel-workbench
         - dynamixel-workbench-msgs
+        - geometry2
+        - orocos_kinematics_dynamics
         - pointcloud_to_laserscan
+        - vision_opencv
     - scripts
     - udp_bridge
     - wolfgang_robot:


### PR DESCRIPTION
## Proposed changes
This pull request updates all shebangs to python3 as we will discuss in our weekly. Also the submodules for the nuc have to be adapted to build the necessary packages for python3.

## Necessary checks
- [ ] ~~Update package version~~
- [ ] Run linters
- [x] Run `catkin build`
- [ ] Write documentation
- [x] Test on your machine
- [x] Test on the robot

