### PR TITLE
Use python 3 in scripts

### DIFF
--- a/scripts/install.pl
+++ b/scripts/install.pl
@@ -71,7 +71,7 @@ sub create_catkin_workspace() {
     mkdir $location;
     chdir $location;
     mkdir $location . "/src";
-    system "bash -c \"source $ROS_WORKSPACE/setup.bash && catkin init && catkin build\"";
+    system "bash -c \"source $ROS_WORKSPACE/setup.bash && catkin init && catkin config -DPYTHON_VERSION=3 && catkin build\"";
 }
 
 sub link_bitbots_meta() {

--- a/scripts/install_py_extensions.bash
+++ b/scripts/install_py_extensions.bash
@@ -1,5 +1,4 @@
 #!/bin/bash
 
 cd $(dirname $0)/../bitbots_vision/python_extensions/
-python2 setup.py install --user
 python3 setup.py install --user

--- a/scripts/pull_all.sh
+++ b/scripts/pull_all.sh
@@ -1,12 +1,6 @@
 #!/bin/bash
 set -e
 
-git submodule update --init lib/dwa_local_planner
-git -C lib/dwa_local_planner checkout master
-git submodule update --init lib/vision_opencv
-git -C lib/vision_opencv checkout melodic
-git submodule update --init lib/geometry2
-git -C lib/geometry2 checkout melodic-devel
 git submodule foreach git pull
 if [[ -d basler_drivers ]]; then
     git -C basler_drivers pull


### PR DESCRIPTION
## Proposed changes
This sets the python version to 3 when the workspace is installed and when building on the robot.

## Necessary checks
- [ ] ~~Update package version~~
- [ ] Run linters
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Test on your machine
- [ ] Test on the robot

