### PR TITLE
Add vision in sync includes for the nuc

### DIFF
--- a/sync_includes_wolfgang_nuc.yaml
+++ b/sync_includes_wolfgang_nuc.yaml
@@ -1,4 +1,5 @@
 include:
+    - basler_drivers
     - bitbots_behavior:
         - bitbots_blackboard
         - bitbots_body_behavior
@@ -54,6 +55,10 @@ include:
         - wolfgang_animations
         - wolfgang_description
         - wolfgang_moveit_config
+    - bitbots_vision:
+        - bitbots_vision
+        - python_extensions
+        - white_balancer
 exclude:
     - "*.bag"
     - "*.pyc"


### PR DESCRIPTION
Add vision in sync includes for the nuc. This is needed to run the vision on the NCS2 TPU.

## Proposed changes
Change sync_includes

## Related issues
https://github.com/bit-bots/bitbots_vision/pull/170

## Necessary checks
- [ ] Update package version
- [ ] Run linters
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Test on your machine
- [ ] Test on the robot

