### PR TITLE
Add Pose estimataion to meta

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -67,3 +67,6 @@
 [submodule "lib/rot_conv_lib"]
 	path = lib/rot_conv_lib
 	url = git@github.com:bit-bots/rot_conv_lib.git
+[submodule "human_pose_estimation_openvino"]
+	path = human_pose_estimation_openvino
+	url = git@github.com:bit-bots/human_pose_estimation_openvino.git

--- a/sync_includes_wolfgang_nuc.yaml
+++ b/sync_includes_wolfgang_nuc.yaml
@@ -38,6 +38,7 @@ include:
     - humanoid_league_msgs
     - humanoid_league_visualization:
         - humanoid_league_rviz_marker
+    - human_pose_estimation_openvino
     - lib:
         - rot_conv_lib
         - bio_ik
@@ -60,6 +61,7 @@ include:
         - bitbots_vision
         - python_extensions
         - white_balancer
+        - bitbots_gestures
 exclude:
     - "*.bag"
     - "*.pyc"


### PR DESCRIPTION
## Proposed changes
This adds a new git that provides human pose estimation to the meta.

## Necessary checks
- [x] Update package version
- [x] Run `catkin build`
- [x] Write documentation
- [x] Create issues for future work
- [x] Test on your machine
- [x] Test on the robot
- [x] Put the PR on our Project board

