### PR TITLE
Update requirements, make install script install from requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,8 @@ PyQt5
 PyYAML
 breathe
 construct
+defusedxml
+filterpy
 matplotlib
 numpy
 opencv-python

--- a/scripts/install.pl
+++ b/scripts/install.pl
@@ -131,9 +131,7 @@ sub install_rosdeps() {
 
 sub install_pip() {
     print "Installing python dependencies...$/";
-    # Formatting: ("package1", "package2")
-    my @python3 = ("defusedxml");
-    system "pip3 install --user " . join(" ", @python3) and die "pip3 package installation failed";
+    system "pip3 install --user -r $start_dir/requirements.txt" and die "pip3 package installation failed";
 }
 
 sub first_catkin_build() {


### PR DESCRIPTION
## Proposed changes
This adds `filterpy` and `defusedxml` to `requirements.txt` and makes the install script install from the requirements file, too.

## Related issues
`filterpy` is required for https://github.com/bit-bots/bitbots_world_model/pull/3