### PR TITLE
add 'deprecated' to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ PyYAML
 breathe
 construct
 defusedxml
+deprecated
 filterpy
 matplotlib
 numpy


### PR DESCRIPTION
## Proposed changes
The [deprecated](https://pypi.org/project/Deprecated/) library is used by `bitbots_test` to indicate deprecated
functions. Although it has been added as a dependency in the packages
`package.xml` file, the key is not rosdep resolvable so the library is
added here as well.

## Related issues
The `deprecated` library is added to `bitbots_test` in https://github.com/bit-bots/bitbots_tools/pull/111

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Put the PR on our Project board

