### PR TITLE
remove PyQt5 from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-PyQt5
 PyYAML
 breathe
 construct


### PR DESCRIPTION
## Proposed changes
<!--- Describe your changes and why they are necessary. -->
I got an error when executing our stack after reinstalling it. pip uninstall PyQt5 fixed it for me.

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Necessary checks
- [ ] Update package version
- [X] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [X] Test on your machine (i am now running into other issues, but it seems to have fixed the original one)
- [ ] Test on the robot
- [ ] Put the PR on our Project board

