### PR TITLE
Use our fork of spatio_temporal_voxel_layer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -70,3 +70,7 @@
 [submodule "bitbots_world_model"]
 	path = bitbots_world_model
 	url = ../../bit-bots/bitbots_world_model.git
+[submodule "lib/spatio_temporal_voxel_layer"]
+	path = lib/spatio_temporal_voxel_layer
+	url = ../../bit-bots/spatio_temporal_voxel_layer
+	branch = melodic-devel


### PR DESCRIPTION
## Proposed changes
The current version of spation_temporal_voxel_layer uses walltime instead of ros time. We use our fork until the issue is fixed upstream.