### PR TITLE
Remove ros_pathes from sync includes

### DIFF
--- a/sync_includes_wolfgang_nuc.yaml
+++ b/sync_includes_wolfgang_nuc.yaml
@@ -12,7 +12,6 @@ include:
         - bitbots_convenience_frames
         - bitbots_teleop
         - system_monitor
-        - bitbots_ros_patches
     - bitbots_motion:
         - bitbots_animation_server
         - bitbots_dynamic_kick


### PR DESCRIPTION
## Proposed changes
Introduced in #103.
Remove `bitbots_ros_patches` as it is not needed anymore.
