### PR TITLE
feat(lib): rm manual built rot_conv_lib

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -58,9 +58,6 @@
 [submodule "lib/particle_filter"]
 	path = lib/particle_filter
 	url = ../../bit-bots/particle_filter.git
-[submodule "lib/rot_conv_lib"]
-	path = lib/rot_conv_lib
-	url = ../../bit-bots/rot_conv_lib.git
 [submodule "bitbots_world_model"]
 	path = bitbots_world_model
 	url = ../../bit-bots/bitbots_world_model.git

--- a/sync_includes_wolfgang_nuc.yaml
+++ b/sync_includes_wolfgang_nuc.yaml
@@ -57,14 +57,13 @@ include:
         - dynamixel-workbench-msgs
         - fp
         - imu_tools
+        - ipm
         - navigation2
-        - orocos_kinematics_dynamics
         - particle_filter
         - pylon-ros-camera
         - robot_controllers
         - ros2_python_extension
         - spatio_temporal_voxel_layer
-        - tf2_geometry_msgs
         - vision_msgs
     - scripts
     - udp_bridge

--- a/sync_includes_wolfgang_nuc.yaml
+++ b/sync_includes_wolfgang_nuc.yaml
@@ -63,7 +63,6 @@ include:
         - pylon-ros-camera
         - robot_controllers
         - ros2_python_extension
-        - rot_conv_lib
         - spatio_temporal_voxel_layer
         - tf2_geometry_msgs
         - vision_msgs


### PR DESCRIPTION
as it now exists as apt package ros-rolling-rot-conv under ubuntu jammy,
which is setup with [ansible].

[ansible]: https://git.mafiasi.de/Bit-Bots/ansible/pulls/13#issuecomment-5560

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

