### PR TITLE
fix setting correct version for hcm package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ pytorchyolo
 rosdep
 rospkg
 setuptools
+scikit-learn==0.23.1
 sklearn
 transforms3d
 git+https://github.com/SammyRamone/stable-baselines3.git


### PR DESCRIPTION
## Proposed changes
HCM needs special version of scikit-learn since it uses old pickle files

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Put the PR on our Project board

