### PR TITLE
Fix ros2_numpy branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -88,5 +88,6 @@
 	url = ../../Flova/ipm.git
 	branch = soccer_ipm
 [submodule "lib/ros2_numpy"]
-	path = lib/ros2_numpy
+    path = lib/ros2_numpy
+    branch = rolling
 	url = ../../Box-Robotics/ros2_numpy.git


### PR DESCRIPTION
## Proposed changes
`ros2_numpy` now uses the rolling branch

