### PR TITLE
Fix: Sync extrinsic_calibration to robot

### DIFF
--- a/sync_includes_wolfgang_nuc.yaml
+++ b/sync_includes_wolfgang_nuc.yaml
@@ -12,6 +12,7 @@ include:
         - bitbots_basler_camera
         - bitbots_bringup
         - bitbots_convenience_frames
+        - bitbots_extrinsic_calibration
         - bitbots_teleop
         - bitbots_utils
         - system_monitor


### PR DESCRIPTION
## Proposed changes
Add `extrinsic calibration` to sync includes