### PR TITLE
Add hlvs_player as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -82,6 +82,10 @@
 	path = lib/events-executor
 	url = ../../irobot-ros/events-executor
 	branch = main
+[submodule "lib/hlvs_player"]
+	path = lib/hlvs_player
+	url = ../../ros-sports/hlvs_player
+	branch = main
 [submodule "lib/humanoid_base_footprint"]
 	path = lib/humanoid_base_footprint
 	url = ../../ros-sports/humanoid_base_footprint.git


### PR DESCRIPTION
Adds hlvs_player as a submodule to bitbots_meta.

Required for bit-bots/wolfgang_robot#252.