### PR TITLE
add wolfgang webots to sync

### DIFF
--- a/sync_includes_wolfgang_nuc.yaml
+++ b/sync_includes_wolfgang_nuc.yaml
@@ -68,6 +68,7 @@ include:
         - wolfgang_animations
         - wolfgang_description
         - wolfgang_moveit_config
+        - wolfgang_webots_sim
 exclude:
     - "*.bag"
     - "*.pyc"


### PR DESCRIPTION
## Proposed changes
Temporarily add wolfgang_webots_sim to be synced to robot.

## Related issues
See 

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Put the PR on our Project board

