### PR TITLE
fix(robot_compile): add timeout of 0.5s to online check

### DIFF
--- a/scripts/robot_compile.py
+++ b/scripts/robot_compile.py
@@ -444,7 +444,7 @@ def internet_available(target):
 
     apt_mirror = "de.archive.ubuntu.com"
     redirect_output = "> /dev/null" if _should_run_quietly() else ""
-    return _execute_on_target(target, f"curl -sSLI {apt_mirror} {redirect_output}").returncode == 0
+    return _execute_on_target(target, f"timeout --foreground 0.5 curl -sSLI {apt_mirror} {redirect_output}").returncode == 0
 
 
 def main():


### PR DESCRIPTION
deciding wether to run `rosdep install` or not

