### PR TITLE
Remove wolfgang_webots_sim from sync includes

### DIFF
--- a/sync_includes_wolfgang_nuc.yaml
+++ b/sync_includes_wolfgang_nuc.yaml
@@ -68,7 +68,6 @@ include:
         - wolfgang_animations
         - wolfgang_description
         - wolfgang_moveit_config
-        - wolfgang_webots_sim
 exclude:
     - "*.bag"
     - "*.pyc"


### PR DESCRIPTION
## Proposed changes
- Removes the package `wolfgang_webots_sim` from sync-includes as it is not needed on the robot.

## Related issues
Fixes #187
Together with bit-bots/bitbots_misc/pull/218 and bit-bots/bitbots_tools/pull/143

## Necessary checks
- [X] Put the PR on our Project board

