### PR TITLE
Remove humanoid league visualization

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -36,9 +36,6 @@
 [submodule "humanoid_league_msgs"]
 	path = humanoid_league_msgs
 	url = ../../bit-bots/humanoid_league_msgs.git
-[submodule "humanoid_league_visualization"]
-	path = humanoid_league_visualization
-	url = ../../bit-bots/humanoid_league_visualization.git
 [submodule "udp_bridge"]
 	path = udp_bridge
 	url = ../../bit-bots/udp_bridge.git


### PR DESCRIPTION
## Proposed changes
- Remove the repo from the meta after https://github.com/bit-bots/humanoid_league_visualization/pull/38 is merged

