### PR TITLE
Cleanup: make pull-files wget less verbose

### DIFF
--- a/scripts/pull_files.bash
+++ b/scripts/pull_files.bash
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 META=$(dirname $(dirname $(realpath $0)))
-rm -rf $META/bitbots_vision/bitbots_vision/models/fcnn03 $META/bitbots_vision/bitbots_vision/models/fcnn031 $META/bitbots_vision/bitbots_vision/models/fcnn032 $META/bitbots_vision/bitbots_vision/models/classifier01
-wget -r -N -np -nH -P $META/bitbots_vision/bitbots_vision --reject "index.html*" "https://data.bit-bots.de/models/"
+wget --no-verbose --show-progress --recursive --timestamping --no-parent --no-host-directories --directory-prefix=$META/bitbots_vision/bitbots_vision --reject "index.html*" "https://data.bit-bots.de/models/"
 
-wget -r -N -np -nH -P $META/bitbots_motion/bitbots_rl_motion --reject "index.html*" "https://data.bit-bots.de/rl_walk_models/"
+wget --no-verbose --show-progress --recursive --timestamping --no-parent --no-host-directories --directory-prefix=$META/bitbots_motion/bitbots_rl_motion --reject "index.html*" "https://data.bit-bots.de/rl_walk_models/"


### PR DESCRIPTION
## Proposed changes
- Using `--no-verbose` flag in wget command, we get less verbose output, but still errors and handled files
- Using `--show-progress` we still get a progress bar for each file
- Replace shorthand flags with full flags for better readability
- Remove old `rm` command to remove old files

## Related issues

