### PR TITLE
Bump ros setup action version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Set up ROS ecosystem
-        uses: ros-tooling/setup-ros@v0.3
+        uses: ros-tooling/setup-ros@v0.7
       - name: Check out repository
         uses: actions/checkout@v3
       - name: Configure git to trust repository


### PR DESCRIPTION
# Summary
Currently, there is a warning due to an old node version being used for the ros setup part. This hopefully fixes that.