### PR TITLE
fix(pip): add `transforms3d` to requirements

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -2,6 +2,7 @@
 filterpy
 pip
 pytorchyolo
+transforms3d
 git+https://github.com/SammyRamone/stable-baselines3.git
 git+https://github.com/bit-bots/deep_quintic.git
 git+https://github.com/Flova/pyastar2d


### PR DESCRIPTION
because otherwise we use the apt system version 0.3.1 from 2017. This lead to issues in combination with newer `numpy` versions, which are installed by our requirements due to dependencies on it by other packages (e.g. YOEO).
This would lead to our software stack not being launchable on fresh setups.

Fixes: #215

## Checklist

- [x] Run `colcon build`
- [ ] Write documentation
- [x] Create issues for future work
- [x] Test on your machine
- [x] Test on the robot
- [x] This PR is on our `Software` project board
