### PR TITLE
Fix sync includes after cleanup

### DIFF
--- a/sync_includes_wolfgang_nuc.yaml
+++ b/sync_includes_wolfgang_nuc.yaml
@@ -10,6 +10,7 @@ include:
         - bitbots_bringup
         - bitbots_extrinsic_calibration
         - bitbots_ipm
+        - bitbots_robot_description
         - bitbots_teleop
         - bitbots_tf_listener
         - bitbots_utils


### PR DESCRIPTION
# Summary
`bitbots_robot_description` was missing in the sync includes.

## Proposed changes
Add it

## Checklist

- [x] Run `colcon build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [x] Test on the robot
- [x] This PR is on our `Software` project board
