### PR TITLE
Use Makefile instead of make_* scripts

### DIFF
--- a/scripts/make_install.sh
+++ b/scripts/make_install.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-scripts/make_basler.sh
-scripts/make_update.sh

--- a/scripts/make_pip.sh
+++ b/scripts/make_pip.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-# Install and upgrade pip dependencies
-pip install --upgrade -r requirements/dev.txt

--- a/scripts/make_pre-commit.sh
+++ b/scripts/make_pre-commit.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-# Install pre-commit hooks for all submodules that have a .pre-commit-config.yaml file
-git submodule foreach "test -f .pre-commit-config.yaml && pre-commit install || :"

--- a/scripts/make_rosdep.sh
+++ b/scripts/make_rosdep.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-# Update rosdep and install dependencies from meta directory
-rosdep update
-rosdep install -iry --from-paths .

--- a/scripts/make_update.sh
+++ b/scripts/make_update.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-scripts/make_rosdep.sh
-scripts/make_pip.sh
-scripts/make_pre-commit.sh


### PR DESCRIPTION
# Summary
Currently, scripts that call new scripts are used for dependencies in our `make ...` commands, but this is already supported by `Makefile`. This PR removes these scripts.
