### PR TITLE
team_communication: automatically detect target ip address

### DIFF
--- a/bitbots_team_communication/bitbots_team_communication/config/team_communication_config.yaml
+++ b/bitbots_team_communication/bitbots_team_communication/config/team_communication_config.yaml
@@ -1,20 +1,14 @@
 team_comm:
   ros__parameters:
-    # UDP broadcast address is the highest IP in the subnet e.g. 172.20.255.255
-    # Sets local mode if set to loopback (127.0.0.1)
+    # Automatically detect UDP broadcast address
+    detect_target_ip: true
+    wifi_interface: "wlp3s0"
+    # Fallback, only used if detect_target_ip is false. This should be the highest IP in the subnet e.g. 172.20.255.255
     target_ip: 192.168.255.255
 
     # Only used in non local mode with specific target_ip
     target_port: 3737
     receive_port: 3737
-
-    # Only used in local mode on loopback
-    # the team communication will bind to one of these ports and send to the other ports, depending on its bot_id
-    local_target_ports:
-      - 4001
-      - 4002
-      - 4003
-      - 4004
 
     # Rate of published messages in Hz
     rate: 10


### PR DESCRIPTION
# Summary
Automatically detect the target address for team communication from the wifi interface using `netifaces`.
In case of any problem, the default address configured is used.

## Related issues
Closes #578.

## Checklist

- [ ] Run `colcon build`
- [ ] Write documentation
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Create issues for future work
- [ ] Triage this PR and label it
