### PR TITLE
Reset the walk cycle when the manual penalty is activated.

### DIFF
--- a/bitbots_motion/bitbots_quintic_walk/src/walk_node.cpp
+++ b/bitbots_motion/bitbots_quintic_walk/src/walk_node.cpp
@@ -117,7 +117,8 @@ void WalkNode::run() {
     if (robot_state_ == bitbots_msgs::msg::RobotControlState::FALLING ||
         robot_state_ == bitbots_msgs::msg::RobotControlState::GETTING_UP ||
         robot_state_ == bitbots_msgs::msg::RobotControlState::PENALTY) {
-       // The robot fell or the penalty button was pressed. We have to reset everything and do nothing else to ensure a stable restart afterwards.
+      // The robot fell or the penalty button was pressed.
+      // We have to reset everything and do nothing else to ensure a stable restart afterwards.
       walk_engine_.reset();
       stabilizer_.reset();
     } else {


### PR DESCRIPTION
This leads to a smooth start once the penalty ends (green button press). A similar thing is already done if we fall down.

## Checklist

- [x] Run `colcon build`
- [ ] Write documentation
- [x] Test on your machine
- [x] Test on the robot
- [ ] Create issues for future work
- [x] Triage this PR and label it
