### PR TITLE
Fix broken `playsound` dependency

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -73,6 +73,7 @@
         "pathfinding",
         "penaltykick",
         "penaltyshoot",
+        "playsound",
         "pointcloud",
         "pointclouds",
         "popen",

--- a/bitbots_behavior/bitbots_body_behavior/bitbots_body_behavior/behavior_dsd/actions/speak.py
+++ b/bitbots_behavior/bitbots_body_behavior/bitbots_body_behavior/behavior_dsd/actions/speak.py
@@ -26,13 +26,13 @@ class PlaySound(AbstractActionElement):
 
     def perform(self, reevaluate=False):
         try:
-            import playsound
+            import playsound3
         except ImportError:
             return self.pop()
 
         try:
-            playsound.playsound(self.audio_file, block=False)
-        except playsound.PlaysoundException:
+            playsound3.playsound(self.audio_file, block=False)
+        except playsound3.playsound3.PlaysoundException:
             pass
 
         return self.pop()

--- a/requirements/robot.txt
+++ b/requirements/robot.txt
@@ -1,7 +1,7 @@
 # This file is used for installation of dependencies on the robot
 -r common.txt  # Includes all common dependencies
 mycroft-mimic3-tts
-protobuf==3.20.3 # Required for mycroft-mimic3-tts, but we want to enshure that the version is compatible binaries build using the system version, but it should also be compatiple with all the python dependencies
+protobuf==3.20.3 # Required for mycroft-mimic3-tts, but we want to ensure that the version is compatible binaries build using the system version, but it should also be compatible with all the python dependencies
 pyttsx3
-playsound
+playsound3
 pyamdgpuinfo


### PR DESCRIPTION
# Summary
Replace unmaintained dependency `playsound` with `playsound3`.
Fixes dependency installation locally and in CI.

## Proposed changes
<!--- Describe your changes and why they are necessary. -->

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Checklist

- [ ] Run `colcon build`
- [ ] Write documentation
- [X] Test on your machine
- [ ] Test on the robot
- [ ] Create issues for future work
- [X] Triage this PR and label it
