### PR TITLE
fix(bitbots_ros_control): dynamixel driver include

### DIFF
--- a/src/bitbots_lowlevel/bitbots_ros_control/include/bitbots_ros_control/bitfoot_hardware_interface.hpp
+++ b/src/bitbots_lowlevel/bitbots_ros_control/include/bitbots_ros_control/bitfoot_hardware_interface.hpp
@@ -1,7 +1,7 @@
 #ifndef BITBOTS_ROS_CONTROL_INCLUDE_BITBOTS_ROS_CONTROL_BITFOOT_HARDWARE_INTERFACE_H_
 #define BITBOTS_ROS_CONTROL_INCLUDE_BITBOTS_ROS_CONTROL_BITFOOT_HARDWARE_INTERFACE_H_
 
-#include <dynamixel_driver.h>
+#include <dynamixel_workbench_toolbox/dynamixel_driver.h>
 
 #include <bitbots_msgs/msg/foot_pressure.hpp>
 #include <bitbots_ros_control/hardware_interface.hpp>

--- a/src/bitbots_lowlevel/bitbots_ros_control/include/bitbots_ros_control/button_hardware_interface.hpp
+++ b/src/bitbots_lowlevel/bitbots_ros_control/include/bitbots_ros_control/button_hardware_interface.hpp
@@ -1,7 +1,7 @@
 #ifndef BITBOTS_ROS_CONTROL_INCLUDE_BITBOTS_ROS_CONTROL_BUTTON_HARDWARE_INTERFACE_H_
 #define BITBOTS_ROS_CONTROL_INCLUDE_BITBOTS_ROS_CONTROL_BUTTON_HARDWARE_INTERFACE_H_
 
-#include <dynamixel_driver.h>
+#include <dynamixel_workbench_toolbox/dynamixel_driver.h>
 
 #include <bitbots_msgs/msg/buttons.hpp>
 #include <bitbots_ros_control/hardware_interface.hpp>

--- a/src/bitbots_lowlevel/bitbots_ros_control/include/bitbots_ros_control/core_hardware_interface.hpp
+++ b/src/bitbots_lowlevel/bitbots_ros_control/include/bitbots_ros_control/core_hardware_interface.hpp
@@ -1,7 +1,7 @@
 #ifndef BITBOTS_ROS_CONTROL_INCLUDE_BITBOTS_ROS_CONTROL_CORE_HARDWARE_INTERFACE_H_
 #define BITBOTS_ROS_CONTROL_INCLUDE_BITBOTS_ROS_CONTROL_CORE_HARDWARE_INTERFACE_H_
 
-#include <dynamixel_driver.h>
+#include <dynamixel_workbench_toolbox/dynamixel_driver.h>
 
 #include <bitbots_ros_control/hardware_interface.hpp>
 #include <bitbots_ros_control/utils.hpp>

--- a/src/bitbots_lowlevel/bitbots_ros_control/include/bitbots_ros_control/dynamixel_servo_hardware_interface.hpp
+++ b/src/bitbots_lowlevel/bitbots_ros_control/include/bitbots_ros_control/dynamixel_servo_hardware_interface.hpp
@@ -1,7 +1,7 @@
 #ifndef BITBOTS_ROS_CONTROL_INCLUDE_BITBOTS_ROS_CONTROL_DYNAMIXEL_SERVO_HARDWARE_INTERFACE_H_
 #define BITBOTS_ROS_CONTROL_INCLUDE_BITBOTS_ROS_CONTROL_DYNAMIXEL_SERVO_HARDWARE_INTERFACE_H_
 
-#include <dynamixel_driver.h>
+#include <dynamixel_workbench_toolbox/dynamixel_driver.h>
 
 #include <bitbots_msgs/msg/joint_command.hpp>
 #include <bitbots_msgs/msg/joint_torque.hpp>

--- a/src/bitbots_lowlevel/bitbots_ros_control/include/bitbots_ros_control/imu_hardware_interface.hpp
+++ b/src/bitbots_lowlevel/bitbots_ros_control/include/bitbots_ros_control/imu_hardware_interface.hpp
@@ -1,7 +1,7 @@
 #ifndef BITBOTS_ROS_CONTROL_INCLUDE_BITBOTS_ROS_CONTROL_IMU_HARDWARE_INTERFACE_H_
 #define BITBOTS_ROS_CONTROL_INCLUDE_BITBOTS_ROS_CONTROL_IMU_HARDWARE_INTERFACE_H_
 
-#include <dynamixel_driver.h>
+#include <dynamixel_workbench_toolbox/dynamixel_driver.h>
 
 #include <bitbots_msgs/srv/accelerometer_calibration.hpp>
 #include <bitbots_msgs/srv/complementary_filter_params.hpp>

--- a/src/bitbots_lowlevel/bitbots_ros_control/include/bitbots_ros_control/leds_hardware_interface.hpp
+++ b/src/bitbots_lowlevel/bitbots_ros_control/include/bitbots_ros_control/leds_hardware_interface.hpp
@@ -1,7 +1,7 @@
 #ifndef BITBOTS_ROS_CONTROL_INCLUDE_BITBOTS_ROS_CONTROL_LEDS_HARDWARE_INTERFACE_H_
 #define BITBOTS_ROS_CONTROL_INCLUDE_BITBOTS_ROS_CONTROL_LEDS_HARDWARE_INTERFACE_H_
 
-#include <dynamixel_driver.h>
+#include <dynamixel_workbench_toolbox/dynamixel_driver.h>
 
 #include <bitbots_msgs/srv/leds.hpp>
 #include <bitbots_ros_control/hardware_interface.hpp>

--- a/src/bitbots_lowlevel/bitbots_ros_control/include/bitbots_ros_control/servo_bus_interface.hpp
+++ b/src/bitbots_lowlevel/bitbots_ros_control/include/bitbots_ros_control/servo_bus_interface.hpp
@@ -1,7 +1,7 @@
 #ifndef BITBOTS_ROS_CONTROL_INCLUDE_BITBOTS_ROS_CONTROL_SERVO_BUS_INTERFACE_H_
 #define BITBOTS_ROS_CONTROL_INCLUDE_BITBOTS_ROS_CONTROL_SERVO_BUS_INTERFACE_H_
 
-#include <dynamixel_driver.h>
+#include <dynamixel_workbench_toolbox/dynamixel_driver.h>
 
 #include <bitbots_msgs/msg/audio.hpp>
 #include <bitbots_msgs/msg/joint_torque.hpp>


### PR DESCRIPTION
to point to `<dynamixel_workbench_toolbox/dynamixel_driver.h>` the
correct include path for the `pixi` environment and not a local/global
installation coming with the dynamixel workbench GUI.

## Checklist

- [x] Run `pixi run build`
- [ ] Write documentation
- [x] Test on your machine
- [ ] Test on the robot
- [ ] Create issues for future work
- [x] Triage this PR and label it
