### PR TITLE
feat(shell): reintroduce `ros.plugin.sh`

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -228,13 +228,17 @@ pyamdgpuinfo = ">=2.1.7, <3"
 [feature.ros.activation.env]
 ROS_AUTOMATIC_DISCOVERY_RANGE = "LOCALHOST"
 RCUTILS_COLORIZED_OUTPUT = "1"
+RCUTILS_CONSOLE_OUTPUT_FORMAT="[{severity}] [{name}]: {message} ({function_name}() at {file_name}:{line_number})"
 RMW_IMPLEMENTATION = "rmw_cyclonedds_cpp"
 COLCON_LOG_LEVEL = "30"
 PYTHONWARNINGS="ignore:::setuptools.command.install,ignore:::setuptools.command.easy_install,ignore:::pkg_resources,ignore:easy_install command is deprecated,ignore:setup.py install is deprecated"
 WEBOTS_HOME = "$CONDA_PREFIX/share/webots"
 
 [feature.ros.activation]
-scripts = ["install/setup.sh"]
+scripts = [
+    "install/setup.sh",
+    "scripts/ros.plugin.sh",
+]
 
 [environments]
 default = ["ros", "format"]  # Full development environment (excluding robot-only deps)

--- a/scripts/ros.plugin.sh
+++ b/scripts/ros.plugin.sh
@@ -1,0 +1,101 @@
+### Aliases and functions for ROS 2 and colcon usage.
+
+rid() {
+  export ROS_DOMAIN_ID="$1"
+  echo "ROS_DOMAIN_ID set to $ROS_DOMAIN_ID"
+}
+
+# Create a function to update the argcomplete and generate the completion
+# scripts so that tab completion works within `pixi shell` environments.
+update_argcompletes() {
+  local tools=(
+      ros2
+      colcon
+  )
+
+  if [[ -n "${CONDA_PREFIX:-}" ]]; then
+    local completions_path="$CONDA_PREFIX/share/zsh/site-functions"
+
+    if ! [[ -d "$completions_path" ]]; then
+        mkdir -p "$completions_path"
+    fi
+
+    for tool in "${tools[@]}"; do
+        if type "$tool" &> /dev/null; then
+          local _completion="$(register-python-argcomplete "$tool")"
+
+          if ! [[ -f "$completions_path/_$tool" ]]; then
+            echo "_completion" > "$completions_path/_$tool"
+          fi
+        fi
+    done
+  fi
+}
+
+setup_alises() {
+  # check if we are in subdir of $ROS_WORKSPACE and switch to it otherwise
+  alias cdc='[[ "$PWD" = "$ROS_WORKSPACE"* ]] || cd "$ROS_WORKSPACE"'
+
+  alias psh='cdc && pixi shell'
+
+  # ros aliases
+  alias ros2='cdc && pixi run ros2'
+  alias rr='ros2 run'
+  alias rl='ros2 launch'
+
+  alias rte='ros2 topic echo'
+  alias rtl='ros2 topic list'
+  alias rth='ros2 topic hz'
+  alias rtp='ros2 topic pub'
+
+  alias rpl='ros2 param list'
+  alias rpg='ros2 param get'
+
+  # colcon aliases
+  alias colcon='cdc && pixi run colcon'
+  alias cba='cdc && pixi run build'
+  alias cbs='cba --packages-select'
+  alias cb='cba --packages-up-to'
+
+  alias ct='pixi run test'
+  alias cts='ct --packages-select'
+
+  alias cca='pixi run clean'
+
+  # deploy_robots tool aliases
+  alias dp='pixi run deploy --sync --build --print-bit-bot'
+  alias dpfull='dp --install --configure'
+  alias dpclean='dp --clean'
+  alias dplo='dp --skip-local-repo-check'
+
+  # Overwrite some aliases in pixi shell to allow for tab completion
+  # by directly using ros2/colcon instead of the pixi tasks
+  if [[ "$(ps -o comm= -p "$PPID")" == "pixi" ]]; then
+    alias cdc='cd $PIXI_PROJECT_ROOT'
+
+    # ros aliases
+    unalias ros2
+    alias rr='ros2 run'
+    alias rl='ros2 launch'
+
+    alias rte='ros2 topic echo'
+    alias rtl='ros2 topic list'
+    alias rth='ros2 topic hz'
+    alias rtp='ros2 topic pub'
+
+    alias rpl='ros2 param list'
+    alias rpg='ros2 param get'
+
+    # colcon aliases
+    unalias colcon
+    alias cba='cdc && colcon build --symlink-install --cmake-args -G "Unix Makefiles" --continue-on-error'
+    alias cbs='cba --packages-select'
+    alias cb='cba --packages-up-to'
+
+    alias ct='cdc && colcon test --event-handlers console_direct+ --return-code-on-test-failure'
+    alias cts='ct --packages-select'
+  fi
+}
+
+update_argcompletes
+setup_alises


### PR DESCRIPTION
which handles aliases and tab completion for `ros2` and `colcon`.
Only in comparison to previous iterations we now have two expected
modes:
- normal `zsh`
- `zsh` started by `pixi shell` parent process

In a normal `zsh` environment we alias `ros2` and `colcon` commands
to the configured `pixi` tasks in the `ROS_WORKSPACE`.

In a `pixi shell` we instead overwrite those aliases with direct
execution of `ros2` and `colcon` to allow for tab completion.
This helps a lot with commands, that are dependent on the environment
like:
- `ros2 topic echo` (showing available topics on tab)
- `colcon build --packages-select` (showing available packages)

To allow for this tab completion, we have to manually generate the
completions into `$CONDA_PREFIX/share/zsh/site-functions` with
`register-python-argcomplete` as they are not part of the conda
packages.

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce. -->

## Checklist

- [x] Run `pixi run build`
- [ ] Write documentation
- [x] Test on your machine
- [ ] Test on the robot
- [ ] Create issues for future work
- [x] Triage this PR and label it
