### PR TITLE
Fix: don't rsync `.devcontainer` dir on the robot

### DIFF
--- a/.rsyncignore
+++ b/.rsyncignore
@@ -17,6 +17,7 @@ src/bitbots_misc/bitbots_parameter_blackboard/config/game_settings.yaml
 *.idea
 *.pyc
 *.vscode
+*.devcontainer
 
 __pycache__
 


### PR DESCRIPTION
# Summary
`.rsyncignore` defines which files not to copy/rsync onto the robot.
Accidentally, we synced the `.devcontainer` directory on the robot, which is not needed.

## Proposed changes

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce. -->

## Checklist

- [ ] Run `pixi run build`
- [ ] Write documentation
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Create issues for future work
- [ ] Triage this PR and label it
