### PR TITLE
fix(deploy_robots): do not run `rsync` with `--delete`

### DIFF
--- a/scripts/deploy/tasks/sync.py
+++ b/scripts/deploy/tasks/sync.py
@@ -45,7 +45,6 @@ class Sync(AbstractTask):
                 "rsync",
                 "--checksum",
                 "--archive",
-                "--delete",
                 "-e",
                 '"ssh -o StrictHostKeyChecking=no"',
                 f"--exclude-from={os.path.join(self._local_workspace, '.rsyncignore')}",


### PR DESCRIPTION
as we now sync to the home dir and destroy everything otherwise

# Summary
<!--- Provide a general summary of the changes -->

## Proposed changes
<!--- Describe your changes and why they are necessary. -->

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce. -->

## Checklist

- [ ] Run `pixi run build`
- [ ] Write documentation
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Create issues for future work
- [ ] Triage this PR and label it
