### PR TITLE
fix(deploy_robots): default to `bitbots_main` workspace

### DIFF
--- a/scripts/deploy/deploy_robots.py
+++ b/scripts/deploy/deploy_robots.py
@@ -118,8 +118,8 @@ class DeployRobots:
         parser.add_argument(
             "-w",
             "--workspace",
-            default=".",
-            help="Path to the workspace directory to deploy to. Defaults to the current directory.",
+            default="~/bitbots_main",
+            help="Path to the workspace directory to deploy to. Defaults to 'bitbots_main' in $HOME dir.",
         )
         parser.add_argument("--skip-local-repo-check", action="store_true", help="Skip the local repository check.")
 

--- a/scripts/deploy/tasks/sync.py
+++ b/scripts/deploy/tasks/sync.py
@@ -45,6 +45,7 @@ class Sync(AbstractTask):
                 "rsync",
                 "--checksum",
                 "--archive",
+                "--delete",
                 "-e",
                 '"ssh -o StrictHostKeyChecking=no"',
                 f"--exclude-from={os.path.join(self._local_workspace, '.rsyncignore')}",


### PR DESCRIPTION
as we now sync to the home dir otherwise with `rsync --delete` and this results in deleting a bunch of important files e.g. `.zshrc`

# Summary
<!--- Provide a general summary of the changes -->

## Proposed changes
<!--- Describe your changes and why they are necessary. -->

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce. -->

## Checklist

- [x] Run `pixi run build`
- [ ] Write documentation
- [x] Test on your machine
- [x] Test on the robot
- [ ] Create issues for future work
- [ ] Triage this PR and label it
