### PR TITLE
jack trunk offset because he could not walk backwards

### DIFF
--- a/src/bitbots_motion/bitbots_quintic_walk/config/robots/jack.yaml
+++ b/src/bitbots_motion/bitbots_quintic_walk/config/robots/jack.yaml
@@ -3,4 +3,4 @@
 walking:
   ros__parameters:
     engine:
-      trunk_x_offset: 0.0
+      trunk_x_offset: 0.01


### PR DESCRIPTION
# Summary
<!--- Provide a general summary of the changes -->
jack trunk offset because he could not walk backwards

## Proposed changes
<!--- Describe your changes and why they are necessary. -->

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce. -->

## Checklist

- [ ] Run `pixi run build`
- [ ] Write documentation
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Create issues for future work
- [ ] Triage this PR and label it
