### PR TITLE
Fix install instructions and add pixi run basler task

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,18 @@ All code is written as individual ROS 2 packages.
 
 The workspace is managed using the [pixi](https://pixi.sh) package manager. This allows us to have reproducible builds and easy user space dependency management similar to tools like `uv` or `cargo`. This also means that no system wide ROS installation or superuser privileges are required to install or run the code.
 
-Full step-by-step instructions for installing the Bit-Bots software stack and ROS 2 can be found in our documentation [here](https://doku.bit-bots.de/meta/manual/tutorials/install_software_ros2.html).
-
+Full step-by-step instructions for installing the Bit-Bots software stack and ROS 2 can be found in our documentation [here](https://docs.bit-bots.de/meta/manual/tutorials/install_software_ros2.html).
 
 Run the following command inside this repository to build the workspace. All dependencies will be installed automatically. Make sure you have [pixi](https://pixi.sh) installed. A few optional proprietary dependencies will be needed for full functionality, see the documentation for details.
 
 ``` shell
 pixi run build
 ```
+
+The first build will take a while as all dependencies are built from source.
+Subsequent builds will be much faster.
+The first build might fail due to missing dependencies.
+Run `pixi run basler` to install the Basler pylon camera driver.
 
 ## Using the workspace
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -14,6 +14,7 @@ version = "0.1.0"
 [tasks]
 deploy = {cmd = "scripts/deploy_robots.py", description = "Deploys the current environment."}
 format = {cmd = "pre-commit run --all-files", description = "Runs code formatting and linting."}
+basler = {cmd = "scripts/make_basler.sh", description = "Installs the Basler pylon camera driver using dpkg on x86-64 Linux."}
 
 [tasks.build]
 cmd = "colcon build --symlink-install --cmake-args -G 'Unix Makefiles' "

--- a/scripts/make_basler.sh
+++ b/scripts/make_basler.sh
@@ -49,7 +49,7 @@ else
     # Download the pylon driver to temp folder
     wget --no-verbose $SHOW_PROGRESS $PYLON_DOWNLOAD_URL -O /tmp/pylon_${PYLON_VERSION}.tar.gz.gpg
     # Extract the pylon driver
-    mkdir /tmp/pylon
+    mkdir -p /tmp/pylon
     # Decrypt the pylon driver
     gpg --batch --yes --passphrase "12987318371043223" -o /tmp/pylon_${PYLON_VERSION}.tar.gz -d /tmp/pylon_${PYLON_VERSION}.tar.gz.gpg
     # Extract the pylon driver


### PR DESCRIPTION
# Summary
Our main install instructions were broken on systems that were missing pylon drivers.
This adds a hint to the Readme and `pixi run basler` task to launch the `make_basler.sh` script.

## Proposed changes
<!--- Describe your changes and why they are necessary. -->

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce. -->

## Checklist

- [x] Run `pixi run build`
- [x] Write documentation
- [x] Test on your machine
- [ ] Test on the robot
- [ ] Create issues for future work
- [ ] Triage this PR and label it
