### PR TITLE
Assume the volume of goal post while decide to kick straight

### DIFF
--- a/src/bitbots_behavior/bitbots_blackboard/bitbots_blackboard/capsules/pathfinding_capsule.py
+++ b/src/bitbots_behavior/bitbots_blackboard/bitbots_blackboard/capsules/pathfinding_capsule.py
@@ -160,6 +160,7 @@ class PathfindingCapsule(AbstractBlackboardCapsule):
             ball_x, ball_y = self._blackboard.world_model.get_ball_position_xy()
 
             # Play in any part of the opponents goal, not just the center
+            # Adjust for the goal post width (-0.06)
             if abs(ball_y) < self._blackboard.world_model.goal_width / 2 - 0.06:
                 goal_angle = 0
             # Play in the opposite direction if the ball is near the opponent goal back line

--- a/src/bitbots_behavior/bitbots_blackboard/bitbots_blackboard/capsules/pathfinding_capsule.py
+++ b/src/bitbots_behavior/bitbots_blackboard/bitbots_blackboard/capsules/pathfinding_capsule.py
@@ -160,7 +160,7 @@ class PathfindingCapsule(AbstractBlackboardCapsule):
             ball_x, ball_y = self._blackboard.world_model.get_ball_position_xy()
 
             # Play in any part of the opponents goal, not just the center
-            if abs(ball_y) < self._blackboard.world_model.goal_width / 2:
+            if abs(ball_y) < self._blackboard.world_model.goal_width / 2 - 0.06:
                 goal_angle = 0
             # Play in the opposite direction if the ball is near the opponent goal back line
             elif ball_x > self._blackboard.world_model.field_length / 2 - 0.2:


### PR DESCRIPTION
# Summary
<!--- Provide a general summary of the changes -->
In the decision if we are direct infront of the goal we now subtract 6cm (max width of goal post is 12 cm, means 6 cm from the defined center in the config)
## Proposed changes

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
From Issue #729

## Checklist

- [ ] Run `pixi run build`
- [ ] Write documentation
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Create issues for future work
- [ ] Triage this PR and label it
