### PR TITLE
Fix for bug#283, keep walking to role position after whistle detection

### DIFF
--- a/src/bitbots_behavior/bitbots_body_behavior/bitbots_body_behavior/behavior_dsd/main.dsd
+++ b/src/bitbots_behavior/bitbots_body_behavior/bitbots_body_behavior/behavior_dsd/main.dsd
@@ -155,7 +155,7 @@ $IsPenalized
         SET --> $WhistleDetected
             DETECTED --> $SecondaryStateTeamDecider
                 OUR --> #PlayingBehavior
-                OTHER --> #StandAndLook
+                OTHER --> #PositioningReady
                 ELSE --> #PlayingBehavior
             NOT_DETECTED --> $SecondaryStateDecider
                 PENALTYSHOOT --> $SecondaryStateTeamDecider


### PR DESCRIPTION
# Summary
<!--- Provide a general summary of the changes -->
Instead of StandAndLook we resume PositioningReady after detecting the whistle, the fixes #283 within the new game controller / whistle detection logic 

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
#283

## Checklist

- [ ] Run `pixi run build`
- [ ] Write documentation
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Create issues for future work
- [ ] Triage this PR and label it
