### PR TITLE
remove 0 as id for a NONE team in behavior_dsd too

### DIFF
--- a/src/bitbots_behavior/bitbots_body_behavior/bitbots_body_behavior/behavior_dsd/decisions/secondary_state_decider.py
+++ b/src/bitbots_behavior/bitbots_body_behavior/bitbots_body_behavior/behavior_dsd/decisions/secondary_state_decider.py
@@ -75,7 +75,7 @@ class SecondaryStateTeamDecider(AbstractDecisionElement):
                 return "OUR"
             # @TODO: handle this better and potentially adapt KickOffTimeUp
             elif (
-                self.blackboard.gamestate.get_kicking_team() == 255 or self.blackboard.gamestate.get_kicking_team() == 0
+                self.blackboard.gamestate.get_kicking_team() == 255
             ):
                 return "NONE"
 


### PR DESCRIPTION
# Summary
<!--- Provide a general summary of the changes -->
id 0 is not the default value for NONE team in the game controller. This was fixed in a lager update before in the localisation.dsd, but not for the behavior.dsd

## Proposed changes
<!--- Describe your changes and why they are necessary. -->

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce. -->

## Checklist

- [ ] Run `pixi run build`
- [ ] Write documentation
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Create issues for future work
- [ ] Triage this PR and label it
