### PR TITLE
Add explanation for walking on same spot with teleop

### DIFF
--- a/src/bitbots_misc/bitbots_teleop/scripts/teleop_keyboard.py
+++ b/src/bitbots_misc/bitbots_teleop/scripts/teleop_keyboard.py
@@ -52,7 +52,7 @@ f: full stop           F: play walkready animation
 r: reset robot in simulation
 R: reset ball in simulation
 
-Not binded key i.e. g and h: let the robot walk on the same spot
+g: walk on the spot, clear speeds
 
 Head Modes:
 0: Track the last known ball position
@@ -355,15 +355,17 @@ class TeleopKeyboard(Node):
                     self.push_force_y -= 1
                 elif key == "'":
                     self.push_force_y -= 10
-                else:
+                elif key in ("g", "G"):
                     self.x = 0
                     self.y = 0
                     self.z = 0
                     self.a_x = 0
                     self.th = 0
-                    if key == "\x03":
-                        self.a_x = -1
-                        break
+                elif key == "\x03":  # CTRL-C
+                    self.a_x = -1
+                    break
+                else:
+                    print("unknown key: " + str(key))
 
                 self.head_mode_pub.publish(self.head_mode_msg)
 

--- a/src/bitbots_misc/bitbots_teleop/scripts/teleop_keyboard.py
+++ b/src/bitbots_misc/bitbots_teleop/scripts/teleop_keyboard.py
@@ -52,6 +52,8 @@ f: full stop           F: play walkready animation
 r: reset robot in simulation
 R: reset ball in simulation
 
+Not binded key i.e. g and h: let the robot walk on the same spot
+
 Head Modes:
 0: Track the last known ball position
 1: Look generally for all features on the field (ball, goals, corners, center point)


### PR DESCRIPTION
# Summary
<!--- Provide a general summary of the changes -->

## Proposed changes
<!--- Describe your changes and why they are necessary. -->

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce. -->

## Checklist

- [ ] Run `pixi run build`
- [ ] Write documentation
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Create issues for future work
- [x] Triage this PR and label it

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bit-bots/codesmith/bitbots_main/pr/868"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782163355&installation_id=134975672&pr_number=868&repository=bit-bots%2Fbitbots_main&return_to=https%3A%2F%2Fgithub.com%2Fbit-bots%2Fbitbots_main%2Fpull%2F868&signature=554053cf82287ce5e9bad1f074a20037b8b47103b087c801314d27857beb6fee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->