### PR TITLE
Add ARM-CI and fix compile warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.os }}
     env:
       PSModulePath: ""  # Otherwise colcon might think that PowerShell is being used
 

--- a/src/bitbots_navigation/bitbots_localization/include/bitbots_localization/StateDistribution.hpp
+++ b/src/bitbots_navigation/bitbots_localization/include/bitbots_localization/StateDistribution.hpp
@@ -46,19 +46,20 @@ class RobotStateDistributionStartLeft : public particle_filter::StateDistributio
 class RobotStateDistributionOwnSideline : public particle_filter::StateDistribution<RobotState> {
  public:
   RobotStateDistributionOwnSideline(particle_filter::CRandomNumberGenerator& random_number_generator,
-                                    const std::pair<double, double>& field_size);
+                                    double field_size_x, double field_size_y);
 
   const RobotState draw() const override;
 
  private:
   particle_filter::CRandomNumberGenerator random_number_generator_;
-  double field_x, field_y;
+  double field_size_x_;
+  double field_size_y_;
 };
 
 class RobotStateDistributionOpponentHalf : public particle_filter::StateDistribution<RobotState> {
  public:
   RobotStateDistributionOpponentHalf(particle_filter::CRandomNumberGenerator& random_number_generator,
-                                     const std::pair<double, double>& field_size);
+                                     double field_size_x, double field_size_y);
 
   const RobotState draw() const override;
 
@@ -72,8 +73,8 @@ class RobotStateDistributionOpponentHalf : public particle_filter::StateDistribu
 
 class RobotStateDistributionOwnHalf : public particle_filter::StateDistribution<RobotState> {
  public:
-  RobotStateDistributionOwnHalf(particle_filter::CRandomNumberGenerator& random_number_generator,
-                                const std::pair<double, double>& field_size);
+  RobotStateDistributionOwnHalf(particle_filter::CRandomNumberGenerator& random_number_generator, double field_size_x,
+                                double field_size_y);
 
   const RobotState draw() const override;
 

--- a/src/bitbots_navigation/bitbots_localization/include/bitbots_localization/StateDistribution.hpp
+++ b/src/bitbots_navigation/bitbots_localization/include/bitbots_localization/StateDistribution.hpp
@@ -16,7 +16,8 @@ namespace bitbots_localization {
 class RobotStateDistribution : public particle_filter::StateDistribution<RobotState> {
  public:
   RobotStateDistribution(particle_filter::CRandomNumberGenerator& random_number_generator,
-                         std::pair<double, double> initial_robot_pose, std::pair<double, double> field_size);
+                         const std::pair<double, double>& initial_robot_pose,
+                         const std::pair<double, double>& field_size);
 
   const RobotState draw() const override;
 
@@ -32,7 +33,7 @@ class RobotStateDistribution : public particle_filter::StateDistribution<RobotSt
 class RobotStateDistributionStartLeft : public particle_filter::StateDistribution<RobotState> {
  public:
   RobotStateDistributionStartLeft(particle_filter::CRandomNumberGenerator& random_number_generator,
-                                  std::pair<double, double> field_size);
+                                  const std::pair<double, double>& field_size);
 
   const RobotState draw() const override;
 
@@ -44,7 +45,7 @@ class RobotStateDistributionStartLeft : public particle_filter::StateDistributio
 class RobotStateDistributionOwnSideline : public particle_filter::StateDistribution<RobotState> {
  public:
   RobotStateDistributionOwnSideline(particle_filter::CRandomNumberGenerator& random_number_generator,
-                                    std::pair<double, double> field_size);
+                                    const std::pair<double, double>& field_size);
 
   const RobotState draw() const override;
 
@@ -56,7 +57,7 @@ class RobotStateDistributionOwnSideline : public particle_filter::StateDistribut
 class RobotStateDistributionOpponentHalf : public particle_filter::StateDistribution<RobotState> {
  public:
   RobotStateDistributionOpponentHalf(particle_filter::CRandomNumberGenerator& random_number_generator,
-                                     std::pair<double, double> field_size);
+                                     const std::pair<double, double>& field_size);
 
   const RobotState draw() const override;
 
@@ -71,7 +72,7 @@ class RobotStateDistributionOpponentHalf : public particle_filter::StateDistribu
 class RobotStateDistributionOwnHalf : public particle_filter::StateDistribution<RobotState> {
  public:
   RobotStateDistributionOwnHalf(particle_filter::CRandomNumberGenerator& random_number_generator,
-                                std::pair<double, double> field_size);
+                                const std::pair<double, double>& field_size);
 
   const RobotState draw() const override;
 

--- a/src/bitbots_navigation/bitbots_localization/include/bitbots_localization/StateDistribution.hpp
+++ b/src/bitbots_navigation/bitbots_localization/include/bitbots_localization/StateDistribution.hpp
@@ -32,8 +32,8 @@ class RobotStateDistribution : public particle_filter::StateDistribution<RobotSt
 
 class RobotStateDistributionStartLeft : public particle_filter::StateDistribution<RobotState> {
  public:
-  RobotStateDistributionStartLeft(particle_filter::CRandomNumberGenerator& random_number_generator,
-                                  double field_size_x, double field_size_y);
+  RobotStateDistributionStartLeft(particle_filter::CRandomNumberGenerator& random_number_generator, double field_size_x,
+                                  double field_size_y);
 
   const RobotState draw() const override;
 

--- a/src/bitbots_navigation/bitbots_localization/include/bitbots_localization/StateDistribution.hpp
+++ b/src/bitbots_navigation/bitbots_localization/include/bitbots_localization/StateDistribution.hpp
@@ -33,13 +33,14 @@ class RobotStateDistribution : public particle_filter::StateDistribution<RobotSt
 class RobotStateDistributionStartLeft : public particle_filter::StateDistribution<RobotState> {
  public:
   RobotStateDistributionStartLeft(particle_filter::CRandomNumberGenerator& random_number_generator,
-                                  const std::pair<double, double>& field_size);
+                                  double field_size_x, double field_size_y);
 
   const RobotState draw() const override;
 
  private:
   particle_filter::CRandomNumberGenerator random_number_generator_;
-  std::pair<double, double> field_size;
+  double field_size_x_;
+  double field_size_y_;
 };
 
 class RobotStateDistributionOwnSideline : public particle_filter::StateDistribution<RobotState> {

--- a/src/bitbots_navigation/bitbots_localization/include/bitbots_localization/map.hpp
+++ b/src/bitbots_navigation/bitbots_localization/include/bitbots_localization/map.hpp
@@ -45,8 +45,8 @@ class Map {
 
   double get_occupancy(double x, double y);
 
-  std::pair<double, double> getObservationCoordinatesInMapFrame(std::pair<double, double> observation, double stateX,
-                                                                double stateY, double stateT);
+  std::pair<double, double> getObservationCoordinatesInMapFrame(const std::pair<double, double>& observation,
+                                                                double stateX, double stateY, double stateT);
 
   nav_msgs::msg::OccupancyGrid get_map_msg(std::string frame_id, int threshold = -1);
 

--- a/src/bitbots_navigation/bitbots_localization/include/bitbots_localization/map.hpp
+++ b/src/bitbots_navigation/bitbots_localization/include/bitbots_localization/map.hpp
@@ -45,8 +45,8 @@ class Map {
 
   double get_occupancy(double x, double y);
 
-  std::pair<double, double> getObservationCoordinatesInMapFrame(const std::pair<double, double>& observation,
-                                                                double stateX, double stateY, double stateT);
+  void getObservationCoordinatesInMapFrame(double obs_angle, double obs_radius, double stateX, double stateY,
+                                           double stateT, double& result_x, double& result_y);
 
   nav_msgs::msg::OccupancyGrid get_map_msg(std::string frame_id, int threshold = -1);
 

--- a/src/bitbots_navigation/bitbots_localization/include/bitbots_localization/map.hpp
+++ b/src/bitbots_navigation/bitbots_localization/include/bitbots_localization/map.hpp
@@ -45,8 +45,8 @@ class Map {
 
   double get_occupancy(double x, double y);
 
-  void getObservationCoordinatesInMapFrame(double obs_angle, double obs_radius, double stateX, double stateY,
-                                           double stateT, double& result_x, double& result_y);
+  CartesianCoordinates getObservationCoordinatesInMapFrame(PolarCoordinates observation, double stateX, double stateY,
+                                                           double stateT);
 
   nav_msgs::msg::OccupancyGrid get_map_msg(std::string frame_id, int threshold = -1);
 

--- a/src/bitbots_navigation/bitbots_localization/include/bitbots_localization/tools.hpp
+++ b/src/bitbots_navigation/bitbots_localization/include/bitbots_localization/tools.hpp
@@ -18,7 +18,9 @@ struct CartesianCoordinates {
   double y;
 };
 
+PolarCoordinates cartesianToPolar(CartesianCoordinates coordinates);
 PolarCoordinates cartesianToPolar(double x, double y);
+CartesianCoordinates polarToCartesian(PolarCoordinates coordinates);
 CartesianCoordinates polarToCartesian(double angle, double radius);
 double signedAngle(double angle_a, double angle_b);
 double signedAngle(double angle);

--- a/src/bitbots_navigation/bitbots_localization/include/bitbots_localization/tools.hpp
+++ b/src/bitbots_navigation/bitbots_localization/include/bitbots_localization/tools.hpp
@@ -8,8 +8,8 @@
 #include <vector>
 
 namespace bitbots_localization {
-std::pair<double, double> cartesianToPolar(double x, double y);
-std::pair<double, double> polarToCartesian(double t, double r);
+void cartesianToPolar(double x, double y, double& angle, double& radius);
+void polarToCartesian(double t, double r, double& x, double& y);
 double signedAngle(double angle_a, double angle_b);
 double signedAngle(double angle);
 }  // namespace bitbots_localization

--- a/src/bitbots_navigation/bitbots_localization/include/bitbots_localization/tools.hpp
+++ b/src/bitbots_navigation/bitbots_localization/include/bitbots_localization/tools.hpp
@@ -18,9 +18,9 @@ struct CartesianCoordinates {
   double y;
 };
 
-PolarCoordinates cartesianToPolar(CartesianCoordinates coordinates);
+PolarCoordinates cartesianToPolar(const CartesianCoordinates& coordinates);
 PolarCoordinates cartesianToPolar(double x, double y);
-CartesianCoordinates polarToCartesian(PolarCoordinates coordinates);
+CartesianCoordinates polarToCartesian(const PolarCoordinates& coordinates);
 CartesianCoordinates polarToCartesian(double angle, double radius);
 double signedAngle(double angle_a, double angle_b);
 double signedAngle(double angle);

--- a/src/bitbots_navigation/bitbots_localization/include/bitbots_localization/tools.hpp
+++ b/src/bitbots_navigation/bitbots_localization/include/bitbots_localization/tools.hpp
@@ -8,8 +8,18 @@
 #include <vector>
 
 namespace bitbots_localization {
-void cartesianToPolar(double x, double y, double& angle, double& radius);
-void polarToCartesian(double t, double r, double& x, double& y);
+struct PolarCoordinates {
+  double angle;
+  double radius;
+};
+
+struct CartesianCoordinates {
+  double x;
+  double y;
+};
+
+PolarCoordinates cartesianToPolar(double x, double y);
+CartesianCoordinates polarToCartesian(double angle, double radius);
 double signedAngle(double angle_a, double angle_b);
 double signedAngle(double angle);
 }  // namespace bitbots_localization

--- a/src/bitbots_navigation/bitbots_localization/src/MotionModel.cpp
+++ b/src/bitbots_navigation/bitbots_localization/src/MotionModel.cpp
@@ -20,7 +20,8 @@ RobotMotionModel::RobotMotionModel(const particle_filter::CRandomNumberGenerator
 void RobotMotionModel::drift(RobotState& state, geometry_msgs::msg::Vector3 linear_movement,
                              geometry_msgs::msg::Vector3 rotational_movement) const {
   // Convert cartesian coordinates to polarcoordinates with an orientation
-  auto [polar_rot, polar_dist] = cartesianToPolar(linear_movement.x, linear_movement.y);
+  double polar_rot, polar_dist;
+  cartesianToPolar(linear_movement.x, linear_movement.y, polar_rot, polar_dist);
   // get the minimal absolute
   double orientation = signedAngle(rotational_movement.z);
   // Apply sample drift for odom data
@@ -33,8 +34,9 @@ void RobotMotionModel::drift(RobotState& state, geometry_msgs::msg::Vector3 line
 
   // Convert polar coordinates with offset back to cartesian ones, while transforming it into the local frame of each
   // particle
-  auto [cartesian_with_offset_x, cartesian_with_offset_y] =
-      polarToCartesian(state.getTheta() + polar_rot_with_drift, polar_dist_with_drift);
+  double cartesian_with_offset_x, cartesian_with_offset_y;
+  polarToCartesian(state.getTheta() + polar_rot_with_drift, polar_dist_with_drift, cartesian_with_offset_x,
+                   cartesian_with_offset_y);
 
   // Apply new values onto state
   state.setXPos(state.getXPos() + cartesian_with_offset_x);

--- a/src/bitbots_navigation/bitbots_localization/src/MotionModel.cpp
+++ b/src/bitbots_navigation/bitbots_localization/src/MotionModel.cpp
@@ -3,6 +3,7 @@
 //
 
 #include <bitbots_localization/MotionModel.hpp>
+#include <cmath>
 
 namespace bitbots_localization {
 
@@ -25,12 +26,12 @@ void RobotMotionModel::drift(RobotState& state, geometry_msgs::msg::Vector3 line
   double orientation = signedAngle(rotational_movement.z);
   // Apply sample drift for odom data
   // no need for abs polar distance, because its positive every time
-  double polar_rot_with_drift =
-      polar_movement.angle - sample(drift_cov_(0, 0) * polar_movement.radius + drift_cov_(0, 1) * abs(orientation));
-  double polar_dist_with_drift =
-      polar_movement.radius - sample(drift_cov_(1, 0) * polar_movement.radius + drift_cov_(1, 1) * abs(orientation));
+  double polar_rot_with_drift = polar_movement.angle - sample(drift_cov_(0, 0) * polar_movement.radius +
+                                                              drift_cov_(0, 1) * std::abs(orientation));
+  double polar_dist_with_drift = polar_movement.radius - sample(drift_cov_(1, 0) * polar_movement.radius +
+                                                                drift_cov_(1, 1) * std::abs(orientation));
   double orientation_with_drift =
-      orientation - sample(drift_cov_(2, 0) * polar_movement.radius + drift_cov_(2, 1) * abs(orientation));
+      orientation - sample(drift_cov_(2, 0) * polar_movement.radius + drift_cov_(2, 1) * std::abs(orientation));
 
   // Convert polar coordinates with offset back to cartesian ones, while transforming it into the local frame of each
   // particle

--- a/src/bitbots_navigation/bitbots_localization/src/MotionModel.cpp
+++ b/src/bitbots_navigation/bitbots_localization/src/MotionModel.cpp
@@ -20,7 +20,7 @@ RobotMotionModel::RobotMotionModel(const particle_filter::CRandomNumberGenerator
 void RobotMotionModel::drift(RobotState& state, geometry_msgs::msg::Vector3 linear_movement,
                              geometry_msgs::msg::Vector3 rotational_movement) const {
   // Convert cartesian coordinates to polar coordinates with an orientation
-  const PolarCoordinates polar_movement = cartesianToPolar(linear_movement.x, linear_movement.y);
+  const PolarCoordinates polar_movement = cartesianToPolar({linear_movement.x, linear_movement.y});
   // get the minimal absolute
   double orientation = signedAngle(rotational_movement.z);
   // Apply sample drift for odom data
@@ -35,7 +35,7 @@ void RobotMotionModel::drift(RobotState& state, geometry_msgs::msg::Vector3 line
   // Convert polar coordinates with offset back to cartesian ones, while transforming it into the local frame of each
   // particle
   const CartesianCoordinates cartesian_with_offset =
-      polarToCartesian(state.getTheta() + polar_rot_with_drift, polar_dist_with_drift);
+      polarToCartesian({state.getTheta() + polar_rot_with_drift, polar_dist_with_drift});
 
   // Apply new values onto state
   state.setXPos(state.getXPos() + cartesian_with_offset.x);

--- a/src/bitbots_navigation/bitbots_localization/src/MotionModel.cpp
+++ b/src/bitbots_navigation/bitbots_localization/src/MotionModel.cpp
@@ -19,28 +19,27 @@ RobotMotionModel::RobotMotionModel(const particle_filter::CRandomNumberGenerator
 
 void RobotMotionModel::drift(RobotState& state, geometry_msgs::msg::Vector3 linear_movement,
                              geometry_msgs::msg::Vector3 rotational_movement) const {
-  // Convert cartesian coordinates to polarcoordinates with an orientation
-  double polar_rot, polar_dist;
-  cartesianToPolar(linear_movement.x, linear_movement.y, polar_rot, polar_dist);
+  // Convert cartesian coordinates to polar coordinates with an orientation
+  const PolarCoordinates polar_movement = cartesianToPolar(linear_movement.x, linear_movement.y);
   // get the minimal absolute
   double orientation = signedAngle(rotational_movement.z);
   // Apply sample drift for odom data
   // no need for abs polar distance, because its positive every time
-  double polar_rot_with_drift = polar_rot - sample(drift_cov_(0, 0) * polar_dist + drift_cov_(0, 1) * abs(orientation));
+  double polar_rot_with_drift =
+      polar_movement.angle - sample(drift_cov_(0, 0) * polar_movement.radius + drift_cov_(0, 1) * abs(orientation));
   double polar_dist_with_drift =
-      polar_dist - sample(drift_cov_(1, 0) * polar_dist + drift_cov_(1, 1) * abs(orientation));
+      polar_movement.radius - sample(drift_cov_(1, 0) * polar_movement.radius + drift_cov_(1, 1) * abs(orientation));
   double orientation_with_drift =
-      orientation - sample(drift_cov_(2, 0) * polar_dist + drift_cov_(2, 1) * abs(orientation));
+      orientation - sample(drift_cov_(2, 0) * polar_movement.radius + drift_cov_(2, 1) * abs(orientation));
 
   // Convert polar coordinates with offset back to cartesian ones, while transforming it into the local frame of each
   // particle
-  double cartesian_with_offset_x, cartesian_with_offset_y;
-  polarToCartesian(state.getTheta() + polar_rot_with_drift, polar_dist_with_drift, cartesian_with_offset_x,
-                   cartesian_with_offset_y);
+  const CartesianCoordinates cartesian_with_offset =
+      polarToCartesian(state.getTheta() + polar_rot_with_drift, polar_dist_with_drift);
 
   // Apply new values onto state
-  state.setXPos(state.getXPos() + cartesian_with_offset_x);
-  state.setYPos(state.getYPos() + cartesian_with_offset_y);
+  state.setXPos(state.getXPos() + cartesian_with_offset.x);
+  state.setYPos(state.getYPos() + cartesian_with_offset.y);
   double theta = state.getTheta() + orientation_with_drift;
 
   state.setTheta(theta);

--- a/src/bitbots_navigation/bitbots_localization/src/ObservationModel.cpp
+++ b/src/bitbots_navigation/bitbots_localization/src/ObservationModel.cpp
@@ -68,18 +68,16 @@ double RobotPoseObservationModel::measure(const RobotState& state) const {
 void RobotPoseObservationModel::set_measurement_lines_pc(sm::msg::PointCloud2 measurement) {
   // convert to polar
   for (sm::PointCloud2ConstIterator<float> iter_xyz(measurement, "x"); iter_xyz != iter_xyz.end(); ++iter_xyz) {
-    double angle, radius;
-    cartesianToPolar(iter_xyz[0], iter_xyz[1], angle, radius);
-    last_measurement_lines_.emplace_back(angle, radius);
+    const PolarCoordinates measurement_polar = cartesianToPolar(iter_xyz[0], iter_xyz[1]);
+    last_measurement_lines_.emplace_back(measurement_polar.angle, measurement_polar.radius);
   }
 }
 
 void RobotPoseObservationModel::set_measurement_goalposts(sv3dm::msg::GoalpostArray measurement) {
   // convert to polar
   for (sv3dm::msg::Goalpost& post : measurement.posts) {
-    double angle, radius;
-    cartesianToPolar(post.bb.center.position.x, post.bb.center.position.y, angle, radius);
-    last_measurement_goal_.emplace_back(angle, radius);
+    const PolarCoordinates measurement_polar = cartesianToPolar(post.bb.center.position.x, post.bb.center.position.y);
+    last_measurement_goal_.emplace_back(measurement_polar.angle, measurement_polar.radius);
   }
 }
 

--- a/src/bitbots_navigation/bitbots_localization/src/ObservationModel.cpp
+++ b/src/bitbots_navigation/bitbots_localization/src/ObservationModel.cpp
@@ -68,16 +68,18 @@ double RobotPoseObservationModel::measure(const RobotState& state) const {
 void RobotPoseObservationModel::set_measurement_lines_pc(sm::msg::PointCloud2 measurement) {
   // convert to polar
   for (sm::PointCloud2ConstIterator<float> iter_xyz(measurement, "x"); iter_xyz != iter_xyz.end(); ++iter_xyz) {
-    std::pair<double, double> linePolar = cartesianToPolar(iter_xyz[0], iter_xyz[1]);
-    last_measurement_lines_.push_back(linePolar);
+    double angle, radius;
+    cartesianToPolar(iter_xyz[0], iter_xyz[1], angle, radius);
+    last_measurement_lines_.emplace_back(angle, radius);
   }
 }
 
 void RobotPoseObservationModel::set_measurement_goalposts(sv3dm::msg::GoalpostArray measurement) {
   // convert to polar
   for (sv3dm::msg::Goalpost& post : measurement.posts) {
-    std::pair<double, double> postPolar = cartesianToPolar(post.bb.center.position.x, post.bb.center.position.y);
-    last_measurement_goal_.push_back(postPolar);
+    double angle, radius;
+    cartesianToPolar(post.bb.center.position.x, post.bb.center.position.y, angle, radius);
+    last_measurement_goal_.emplace_back(angle, radius);
   }
 }
 

--- a/src/bitbots_navigation/bitbots_localization/src/StateDistribution.cpp
+++ b/src/bitbots_navigation/bitbots_localization/src/StateDistribution.cpp
@@ -23,31 +23,29 @@ const RobotState RobotStateDistributionStartLeft::draw() const {
 }
 
 RobotStateDistributionOwnSideline::RobotStateDistributionOwnSideline(
-    particle_filter::CRandomNumberGenerator& random_number_generator, const std::pair<double, double>& field_size) {
-  field_x = field_size.first;
-  field_y = field_size.second;
-}
+    particle_filter::CRandomNumberGenerator& random_number_generator, double field_size_x, double field_size_y)
+    : random_number_generator_(random_number_generator), field_size_x_(field_size_x), field_size_y_(field_size_y) {}
 
 const RobotState RobotStateDistributionOwnSideline::draw() const {
   if (random_number_generator_.getUniform(0, 1) > 0.5) {
-    return (RobotState(random_number_generator_.getUniform(-field_x / 2, 0.0),
-                       random_number_generator_.getGaussian(0.1) - field_y / 2,
+    return (RobotState(random_number_generator_.getUniform(-field_size_x_ / 2, 0.0),
+                       random_number_generator_.getGaussian(0.1) - field_size_y_ / 2,
                        random_number_generator_.getGaussian(0.2) + 1.57));
   } else {
-    return (RobotState(random_number_generator_.getUniform(-field_x / 2, 0.0),
-                       random_number_generator_.getGaussian(0.1) + field_y / 2,
+    return (RobotState(random_number_generator_.getUniform(-field_size_x_ / 2, 0.0),
+                       random_number_generator_.getGaussian(0.1) + field_size_y_ / 2,
                        random_number_generator_.getGaussian(0.2) - 1.57));
   }
 }
 
 RobotStateDistributionOpponentHalf::RobotStateDistributionOpponentHalf(
-    particle_filter::CRandomNumberGenerator& random_number_generator, const std::pair<double, double>& field_size)
+    particle_filter::CRandomNumberGenerator& random_number_generator, double field_size_x, double field_size_y)
     : random_number_generator_(random_number_generator) {
   // only own half
-  min_x_ = (field_size.first / 2.0) + 0.5;
-  min_y_ = (-field_size.second / 2.0) - 0.5;
+  min_x_ = (field_size_x / 2.0) + 0.5;
+  min_y_ = (-field_size_y / 2.0) - 0.5;
   max_x_ = 0 - 0.5;
-  max_y_ = (field_size.second / 2.0) + 0.5;
+  max_y_ = (field_size_y / 2.0) + 0.5;
 }
 
 const RobotState RobotStateDistributionOpponentHalf::draw() const {
@@ -57,13 +55,13 @@ const RobotState RobotStateDistributionOpponentHalf::draw() const {
 }
 
 RobotStateDistributionOwnHalf::RobotStateDistributionOwnHalf(
-    particle_filter::CRandomNumberGenerator& random_number_generator, const std::pair<double, double>& field_size)
+    particle_filter::CRandomNumberGenerator& random_number_generator, double field_size_x, double field_size_y)
     : random_number_generator_(random_number_generator) {
   // only own half
-  min_x_ = -field_size.first / 2.0;
-  min_y_ = -field_size.second / 2.0;
+  min_x_ = -field_size_x / 2.0;
+  min_y_ = -field_size_y / 2.0;
   max_x_ = 0;
-  max_y_ = field_size.second / 2.0;
+  max_y_ = field_size_y / 2.0;
 }
 
 const RobotState RobotStateDistributionOwnHalf::draw() const {

--- a/src/bitbots_navigation/bitbots_localization/src/StateDistribution.cpp
+++ b/src/bitbots_navigation/bitbots_localization/src/StateDistribution.cpp
@@ -7,17 +7,17 @@
 namespace bitbots_localization {
 
 RobotStateDistributionStartLeft::RobotStateDistributionStartLeft(
-    particle_filter::CRandomNumberGenerator& random_number_generator, const std::pair<double, double>& field_size)
-    : random_number_generator_(random_number_generator), field_size(field_size) {}
+    particle_filter::CRandomNumberGenerator& random_number_generator, double field_size_x, double field_size_y)
+    : random_number_generator_(random_number_generator), field_size_x_(field_size_x), field_size_y_(field_size_y) {}
 
 const RobotState RobotStateDistributionStartLeft::draw() const {
   if (random_number_generator_.getUniform(0, 1) > 0.5) {
-    return (RobotState(random_number_generator_.getUniform(field_size.first / 2, 0.0),
-                       random_number_generator_.getGaussian(0.1) - field_size.second / 2 - 0.1,
+    return (RobotState(random_number_generator_.getUniform(field_size_x_ / 2, 0.0),
+                       random_number_generator_.getGaussian(0.1) - field_size_y_ / 2 - 0.1,
                        random_number_generator_.getGaussian(0.2) - 1.57));
   } else {
-    return (RobotState(random_number_generator_.getUniform(field_size.first / 2, 0.0),
-                       random_number_generator_.getGaussian(0.1) + field_size.second / 2 + 0.1,
+    return (RobotState(random_number_generator_.getUniform(field_size_x_ / 2, 0.0),
+                       random_number_generator_.getGaussian(0.1) + field_size_y_ / 2 + 0.1,
                        random_number_generator_.getGaussian(0.2) + 1.57));
   }
 }

--- a/src/bitbots_navigation/bitbots_localization/src/StateDistribution.cpp
+++ b/src/bitbots_navigation/bitbots_localization/src/StateDistribution.cpp
@@ -7,7 +7,7 @@
 namespace bitbots_localization {
 
 RobotStateDistributionStartLeft::RobotStateDistributionStartLeft(
-    particle_filter::CRandomNumberGenerator& random_number_generator, std::pair<double, double> field_size) {
+    particle_filter::CRandomNumberGenerator& random_number_generator, const std::pair<double, double>& field_size) {
   field_size = field_size;
 }
 
@@ -24,7 +24,7 @@ const RobotState RobotStateDistributionStartLeft::draw() const {
 }
 
 RobotStateDistributionOwnSideline::RobotStateDistributionOwnSideline(
-    particle_filter::CRandomNumberGenerator& random_number_generator, std::pair<double, double> field_size) {
+    particle_filter::CRandomNumberGenerator& random_number_generator, const std::pair<double, double>& field_size) {
   field_x = field_size.first;
   field_y = field_size.second;
 }
@@ -42,7 +42,7 @@ const RobotState RobotStateDistributionOwnSideline::draw() const {
 }
 
 RobotStateDistributionOpponentHalf::RobotStateDistributionOpponentHalf(
-    particle_filter::CRandomNumberGenerator& random_number_generator, std::pair<double, double> field_size)
+    particle_filter::CRandomNumberGenerator& random_number_generator, const std::pair<double, double>& field_size)
     : random_number_generator_(random_number_generator) {
   // only own half
   min_x_ = (field_size.first / 2.0) + 0.5;
@@ -58,7 +58,7 @@ const RobotState RobotStateDistributionOpponentHalf::draw() const {
 }
 
 RobotStateDistributionOwnHalf::RobotStateDistributionOwnHalf(
-    particle_filter::CRandomNumberGenerator& random_number_generator, std::pair<double, double> field_size)
+    particle_filter::CRandomNumberGenerator& random_number_generator, const std::pair<double, double>& field_size)
     : random_number_generator_(random_number_generator) {
   // only own half
   min_x_ = -field_size.first / 2.0;

--- a/src/bitbots_navigation/bitbots_localization/src/StateDistribution.cpp
+++ b/src/bitbots_navigation/bitbots_localization/src/StateDistribution.cpp
@@ -7,9 +7,8 @@
 namespace bitbots_localization {
 
 RobotStateDistributionStartLeft::RobotStateDistributionStartLeft(
-    particle_filter::CRandomNumberGenerator& random_number_generator, const std::pair<double, double>& field_size) {
-  field_size = field_size;
-}
+    particle_filter::CRandomNumberGenerator& random_number_generator, const std::pair<double, double>& field_size)
+    : random_number_generator_(random_number_generator), field_size(field_size) {}
 
 const RobotState RobotStateDistributionStartLeft::draw() const {
   if (random_number_generator_.getUniform(0, 1) > 0.5) {

--- a/src/bitbots_navigation/bitbots_localization/src/localization.cpp
+++ b/src/bitbots_navigation/bitbots_localization/src/localization.cpp
@@ -517,15 +517,15 @@ void Localization::publish_debug_rating(const std::vector<std::pair<double, doub
 
   for (const std::pair<double, double>& measurement : measurements) {
     // lines are in polar form!
-    std::pair<double, double> observationRelative;
+    double obs_x, obs_y;
 
-    observationRelative = map->getObservationCoordinatesInMapFrame(measurement, best_estimate.getXPos(),
-                                                                   best_estimate.getYPos(), best_estimate.getTheta());
-    double occupancy = map->get_occupancy(observationRelative.first, observationRelative.second);
+    map->getObservationCoordinatesInMapFrame(measurement.first, measurement.second, best_estimate.getXPos(),
+                                             best_estimate.getYPos(), best_estimate.getTheta(), obs_x, obs_y);
+    double occupancy = map->get_occupancy(obs_x, obs_y);
 
     geometry_msgs::msg::Point point;
-    point.x = observationRelative.first;
-    point.y = observationRelative.second;
+    point.x = obs_x;
+    point.y = obs_y;
 
     std_msgs::msg::ColorRGBA color;
     color.b = 1;

--- a/src/bitbots_navigation/bitbots_localization/src/localization.cpp
+++ b/src/bitbots_navigation/bitbots_localization/src/localization.cpp
@@ -121,11 +121,11 @@ void Localization::updateParams(bool force_reload) {
 
   // Create standard particle probability distributions (e.g. for the initialization at the start of the game)
   robot_state_distribution_own_sidelines.reset(new RobotStateDistributionOwnSideline(
-      random_number_generator_, std::make_pair(field_dimensions_.x, field_dimensions_.y)));
+      random_number_generator_, std::pair<double, double>{field_dimensions_.x, field_dimensions_.y}));
   robot_state_distribution_opponent_half.reset(new RobotStateDistributionOpponentHalf(
-      random_number_generator_, std::make_pair(field_dimensions_.x, field_dimensions_.y)));
+      random_number_generator_, std::pair<double, double>{field_dimensions_.x, field_dimensions_.y}));
   robot_state_distribution_own_half_.reset(new RobotStateDistributionOwnHalf(
-      random_number_generator_, std::make_pair(field_dimensions_.x, field_dimensions_.y)));
+      random_number_generator_, std::pair<double, double>{field_dimensions_.x, field_dimensions_.y}));
 
   // Create the resampling strategy
   resampling_.reset(

--- a/src/bitbots_navigation/bitbots_localization/src/localization.cpp
+++ b/src/bitbots_navigation/bitbots_localization/src/localization.cpp
@@ -120,12 +120,12 @@ void Localization::updateParams(bool force_reload) {
                                                  config_.particle_filter.diffusion.starting_multiplier, drift_cov));
 
   // Create standard particle probability distributions (e.g. for the initialization at the start of the game)
-  robot_state_distribution_own_sidelines.reset(new RobotStateDistributionOwnSideline(
-      random_number_generator_, std::pair<double, double>{field_dimensions_.x, field_dimensions_.y}));
-  robot_state_distribution_opponent_half.reset(new RobotStateDistributionOpponentHalf(
-      random_number_generator_, std::pair<double, double>{field_dimensions_.x, field_dimensions_.y}));
-  robot_state_distribution_own_half_.reset(new RobotStateDistributionOwnHalf(
-      random_number_generator_, std::pair<double, double>{field_dimensions_.x, field_dimensions_.y}));
+  robot_state_distribution_own_sidelines.reset(
+      new RobotStateDistributionOwnSideline(random_number_generator_, field_dimensions_.x, field_dimensions_.y));
+  robot_state_distribution_opponent_half.reset(
+      new RobotStateDistributionOpponentHalf(random_number_generator_, field_dimensions_.x, field_dimensions_.y));
+  robot_state_distribution_own_half_.reset(
+      new RobotStateDistributionOwnHalf(random_number_generator_, field_dimensions_.x, field_dimensions_.y));
 
   // Create the resampling strategy
   resampling_.reset(

--- a/src/bitbots_navigation/bitbots_localization/src/localization.cpp
+++ b/src/bitbots_navigation/bitbots_localization/src/localization.cpp
@@ -517,15 +517,15 @@ void Localization::publish_debug_rating(const std::vector<std::pair<double, doub
 
   for (const std::pair<double, double>& measurement : measurements) {
     // lines are in polar form!
-    double obs_x, obs_y;
+    const PolarCoordinates measurement_polar{measurement.first, measurement.second};
 
-    map->getObservationCoordinatesInMapFrame(measurement.first, measurement.second, best_estimate.getXPos(),
-                                             best_estimate.getYPos(), best_estimate.getTheta(), obs_x, obs_y);
-    double occupancy = map->get_occupancy(obs_x, obs_y);
+    const CartesianCoordinates observation = map->getObservationCoordinatesInMapFrame(
+        measurement_polar, best_estimate.getXPos(), best_estimate.getYPos(), best_estimate.getTheta());
+    double occupancy = map->get_occupancy(observation.x, observation.y);
 
     geometry_msgs::msg::Point point;
-    point.x = obs_x;
-    point.y = obs_y;
+    point.x = observation.x;
+    point.y = observation.y;
 
     std_msgs::msg::ColorRGBA color;
     color.b = 1;

--- a/src/bitbots_navigation/bitbots_localization/src/map.cpp
+++ b/src/bitbots_navigation/bitbots_localization/src/map.cpp
@@ -73,7 +73,8 @@ CartesianCoordinates Map::getObservationCoordinatesInMapFrame(PolarCoordinates o
   // Output: Observation coordinates in Cartesian coordinates in the map frame
 
   // add theta and convert back to cartesian
-  const CartesianCoordinates observation_with_theta = polarToCartesian(observation.angle + stateT, observation.radius);
+  const CartesianCoordinates observation_with_theta =
+      polarToCartesian({observation.angle + stateT, observation.radius});
 
   // add to particle
   return {stateX + observation_with_theta.x, stateY + observation_with_theta.y};

--- a/src/bitbots_navigation/bitbots_localization/src/map.cpp
+++ b/src/bitbots_navigation/bitbots_localization/src/map.cpp
@@ -64,8 +64,8 @@ std::vector<double> Map::provideRating(const RobotState& state,
   return rating;
 }
 
-std::pair<double, double> Map::getObservationCoordinatesInMapFrame(std::pair<double, double> observation, double stateX,
-                                                                   double stateY, double stateT) {
+std::pair<double, double> Map::getObservationCoordinatesInMapFrame(const std::pair<double, double>& observation,
+                                                                   double stateX, double stateY, double stateT) {
   // queries the Cartesian metric map coordinates for a given observation (in polar coordinates)
   // taken relative to a given state (in Cartesian coordinates)
   // Input: Observation coordinates in polar coordinates, state coordinates in Cartesian coordinates
@@ -75,8 +75,8 @@ std::pair<double, double> Map::getObservationCoordinatesInMapFrame(std::pair<dou
   std::pair<double, double> observationWithTheta = polarToCartesian(observation.first + stateT, observation.second);
 
   // add to particle
-  std::pair<double, double> observationRelative =
-      std::make_pair(stateX + observationWithTheta.first, stateY + observationWithTheta.second);
+  std::pair<double, double> observationRelative{
+      stateX + observationWithTheta.first, stateY + observationWithTheta.second};
 
   return observationRelative;  // in cartesian
 }

--- a/src/bitbots_navigation/bitbots_localization/src/map.cpp
+++ b/src/bitbots_navigation/bitbots_localization/src/map.cpp
@@ -53,32 +53,30 @@ std::vector<double> Map::provideRating(const RobotState& state,
   std::vector<double> rating;
   for (const std::pair<double, double>& observation : observations) {
     // lines are in polar form!
-    double line_x, line_y;
+    const PolarCoordinates observation_polar{observation.first, observation.second};
 
     // get rating per line
-    getObservationCoordinatesInMapFrame(observation.first, observation.second, state.getXPos(), state.getYPos(),
-                                        state.getTheta(), line_x, line_y);
-    double occupancy = get_occupancy(line_x, line_y);
+    const CartesianCoordinates line_relative =
+        getObservationCoordinatesInMapFrame(observation_polar, state.getXPos(), state.getYPos(), state.getTheta());
+    double occupancy = get_occupancy(line_relative.x, line_relative.y);
 
     rating.push_back(occupancy);
   }
   return rating;
 }
 
-void Map::getObservationCoordinatesInMapFrame(double obs_angle, double obs_radius, double stateX, double stateY,
-                                              double stateT, double& result_x, double& result_y) {
+CartesianCoordinates Map::getObservationCoordinatesInMapFrame(PolarCoordinates observation, double stateX,
+                                                              double stateY, double stateT) {
   // queries the Cartesian metric map coordinates for a given observation (in polar coordinates)
   // taken relative to a given state (in Cartesian coordinates)
   // Input: Observation coordinates in polar coordinates, state coordinates in Cartesian coordinates
   // Output: Observation coordinates in Cartesian coordinates in the map frame
 
   // add theta and convert back to cartesian
-  double cart_x, cart_y;
-  polarToCartesian(obs_angle + stateT, obs_radius, cart_x, cart_y);
+  const CartesianCoordinates observation_with_theta = polarToCartesian(observation.angle + stateT, observation.radius);
 
   // add to particle
-  result_x = stateX + cart_x;
-  result_y = stateY + cart_y;
+  return {stateX + observation_with_theta.x, stateY + observation_with_theta.y};
 }
 
 nav_msgs::msg::OccupancyGrid Map::get_map_msg(std::string frame_id, int threshold) {

--- a/src/bitbots_navigation/bitbots_localization/src/map.cpp
+++ b/src/bitbots_navigation/bitbots_localization/src/map.cpp
@@ -53,32 +53,32 @@ std::vector<double> Map::provideRating(const RobotState& state,
   std::vector<double> rating;
   for (const std::pair<double, double>& observation : observations) {
     // lines are in polar form!
-    std::pair<double, double> lineRelative;
+    double line_x, line_y;
 
     // get rating per line
-    lineRelative = getObservationCoordinatesInMapFrame(observation, state.getXPos(), state.getYPos(), state.getTheta());
-    double occupancy = get_occupancy(lineRelative.first, lineRelative.second);
+    getObservationCoordinatesInMapFrame(observation.first, observation.second, state.getXPos(), state.getYPos(),
+                                        state.getTheta(), line_x, line_y);
+    double occupancy = get_occupancy(line_x, line_y);
 
     rating.push_back(occupancy);
   }
   return rating;
 }
 
-std::pair<double, double> Map::getObservationCoordinatesInMapFrame(const std::pair<double, double>& observation,
-                                                                   double stateX, double stateY, double stateT) {
+void Map::getObservationCoordinatesInMapFrame(double obs_angle, double obs_radius, double stateX, double stateY,
+                                              double stateT, double& result_x, double& result_y) {
   // queries the Cartesian metric map coordinates for a given observation (in polar coordinates)
   // taken relative to a given state (in Cartesian coordinates)
   // Input: Observation coordinates in polar coordinates, state coordinates in Cartesian coordinates
   // Output: Observation coordinates in Cartesian coordinates in the map frame
 
   // add theta and convert back to cartesian
-  std::pair<double, double> observationWithTheta = polarToCartesian(observation.first + stateT, observation.second);
+  double cart_x, cart_y;
+  polarToCartesian(obs_angle + stateT, obs_radius, cart_x, cart_y);
 
   // add to particle
-  std::pair<double, double> observationRelative{
-      stateX + observationWithTheta.first, stateY + observationWithTheta.second};
-
-  return observationRelative;  // in cartesian
+  result_x = stateX + cart_x;
+  result_y = stateY + cart_y;
 }
 
 nav_msgs::msg::OccupancyGrid Map::get_map_msg(std::string frame_id, int threshold) {

--- a/src/bitbots_navigation/bitbots_localization/src/tools.cpp
+++ b/src/bitbots_navigation/bitbots_localization/src/tools.cpp
@@ -2,14 +2,10 @@
 
 namespace bitbots_localization {
 
-void cartesianToPolar(double x, double y, double& angle, double& radius) {
-  radius = hypot(x, y);
-  angle = atan2(y, x);
-}
+PolarCoordinates cartesianToPolar(double x, double y) { return {atan2(y, x), hypot(x, y)}; }
 
-void polarToCartesian(double t, double r, double& x, double& y) {
-  x = r * std::cos(t);
-  y = r * std::sin(t);
+CartesianCoordinates polarToCartesian(double angle, double radius) {
+  return {radius * std::cos(angle), radius * std::sin(angle)};
 }
 
 double signedAngle(double angle) {

--- a/src/bitbots_navigation/bitbots_localization/src/tools.cpp
+++ b/src/bitbots_navigation/bitbots_localization/src/tools.cpp
@@ -2,11 +2,17 @@
 
 namespace bitbots_localization {
 
-PolarCoordinates cartesianToPolar(double x, double y) { return {atan2(y, x), hypot(x, y)}; }
-
-CartesianCoordinates polarToCartesian(double angle, double radius) {
-  return {radius * std::cos(angle), radius * std::sin(angle)};
+PolarCoordinates cartesianToPolar(CartesianCoordinates coordinates) {
+  return {atan2(coordinates.y, coordinates.x), hypot(coordinates.x, coordinates.y)};
 }
+
+PolarCoordinates cartesianToPolar(double x, double y) { return cartesianToPolar({x, y}); }
+
+CartesianCoordinates polarToCartesian(PolarCoordinates coordinates) {
+  return {coordinates.radius * std::cos(coordinates.angle), coordinates.radius * std::sin(coordinates.angle)};
+}
+
+CartesianCoordinates polarToCartesian(double angle, double radius) { return polarToCartesian({angle, radius}); }
 
 double signedAngle(double angle) {
   if (angle > M_PI) {

--- a/src/bitbots_navigation/bitbots_localization/src/tools.cpp
+++ b/src/bitbots_navigation/bitbots_localization/src/tools.cpp
@@ -1,4 +1,5 @@
 #include <bitbots_localization/tools.hpp>
+#include <cmath>
 
 namespace bitbots_localization {
 

--- a/src/bitbots_navigation/bitbots_localization/src/tools.cpp
+++ b/src/bitbots_navigation/bitbots_localization/src/tools.cpp
@@ -7,14 +7,14 @@ std::pair<double, double> cartesianToPolar(double x, double y) {
 
   double t = atan2(y, x);
 
-  return std::make_pair(t, r);
+  return {t, r};
 }
 
 std::pair<double, double> polarToCartesian(double t, double r) {
   double x = r * std::cos(t);
   double y = r * std::sin(t);
 
-  return std::make_pair(x, y);
+  return {x, y};
 }
 
 double signedAngle(double angle) {

--- a/src/bitbots_navigation/bitbots_localization/src/tools.cpp
+++ b/src/bitbots_navigation/bitbots_localization/src/tools.cpp
@@ -2,13 +2,13 @@
 
 namespace bitbots_localization {
 
-PolarCoordinates cartesianToPolar(CartesianCoordinates coordinates) {
+PolarCoordinates cartesianToPolar(const CartesianCoordinates& coordinates) {
   return {atan2(coordinates.y, coordinates.x), hypot(coordinates.x, coordinates.y)};
 }
 
 PolarCoordinates cartesianToPolar(double x, double y) { return cartesianToPolar({x, y}); }
 
-CartesianCoordinates polarToCartesian(PolarCoordinates coordinates) {
+CartesianCoordinates polarToCartesian(const PolarCoordinates& coordinates) {
   return {coordinates.radius * std::cos(coordinates.angle), coordinates.radius * std::sin(coordinates.angle)};
 }
 

--- a/src/bitbots_navigation/bitbots_localization/src/tools.cpp
+++ b/src/bitbots_navigation/bitbots_localization/src/tools.cpp
@@ -2,19 +2,14 @@
 
 namespace bitbots_localization {
 
-std::pair<double, double> cartesianToPolar(double x, double y) {
-  double r = hypot(x, y);
-
-  double t = atan2(y, x);
-
-  return {t, r};
+void cartesianToPolar(double x, double y, double& angle, double& radius) {
+  radius = hypot(x, y);
+  angle = atan2(y, x);
 }
 
-std::pair<double, double> polarToCartesian(double t, double r) {
-  double x = r * std::cos(t);
-  double y = r * std::sin(t);
-
-  return {x, y};
+void polarToCartesian(double t, double r, double& x, double& y) {
+  x = r * std::cos(t);
+  y = r * std::sin(t);
 }
 
 double signedAngle(double angle) {

--- a/src/lib/livelybot_hardware_sdk/src/yesense_ros/yesense/src/yesense_driver.cpp
+++ b/src/lib/livelybot_hardware_sdk/src/yesense_ros/yesense/src/yesense_driver.cpp
@@ -1261,7 +1261,7 @@ void YesenseDriver::spin()
     uint16_t tid = 0x00;
     uint16_t prev_tid = 0x00;
 
-    uint32_t gps_header_sum;
+    uint32_t gps_header_sum = 0;
 
     while(configured_)
     {


### PR DESCRIPTION
GCC 10.1+ emits ABI compatibility notes on AArch64 for any function with `std::pair<double, double>` in its ABI (return type or by-value parameter) when compiled with C++17. These notes blocked clean ARM64 CI builds.

## Proposed changes

Replaced all `std::pair<double, double>` occurrences in function ABI boundaries with output parameters or separate doubles:

- **`tools.hpp/cpp`** — `cartesianToPolar` and `polarToCartesian` now use output parameters instead of returning a pair:
  ```cpp
  // Before
  std::pair<double, double> cartesianToPolar(double x, double y);
  // After
  void cartesianToPolar(double x, double y, double& angle, double& radius);
  ```
- **`map.hpp/cpp`** — `getObservationCoordinatesInMapFrame` no longer takes a pair or returns one; uses individual input doubles and output parameters
- **`StateDistribution.hpp/cpp`** — `RobotStateDistributionStartLeft` replaces `std::pair<double, double> field_size` member with `field_size_x_` / `field_size_y_` doubles; constructor updated accordingly
- **`MotionModel.cpp`, `ObservationModel.cpp`, `localization.cpp`** — all call sites updated to match new signatures

## Related issues

Part of ARM64 CI support (PR #871 `feature/ARM64_CI`).

## Checklist

- [x] Run `pixi run build`
- [ ] Write documentation
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Create issues for future work
- [ ] Triage this PR and label it