### PR TITLE
Fix CI by starting zenoh inside pixi

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: pixi run -e default build
 
       - name: Start ZenohD
-        run: ros2 run rmw_zenoh_cpp rmw_zenohd &
+        run: pixi run -e default ros2 run rmw_zenoh_cpp rmw_zenohd &
 
       - name: Test
         run: pixi run -e default test

--- a/pixi.toml
+++ b/pixi.toml
@@ -32,7 +32,7 @@ description = "Cleans build and install files for all ROS 2 packages or a specif
 [tasks.test]
 description = "Runs tests for all ROS 2 packages. Pass additional colcon args (e.g. --packages-select)"
 # Skipping packages in the src/lib directory as they are not "our" responsibility. They should be tested separately in their own repositories.
-cmd = "colcon test --parallel-workers 1 --event-handlers console_direct+ --return-code-on-test-failure --packages-skip audio_common domain_bridge ipm_image_node soccer_ipm zed_wrapper zed_components zed_msgs zed_ros2 "
+cmd = "colcon test --parallel-workers 1 --event-handlers console_direct+ --return-code-on-test-failure --packages-skip audio_common domain_bridge humanoid_base_footprint ipm_image_node soccer_ipm zed_wrapper zed_components zed_msgs zed_ros2 "
 
 [dependencies]
 # Base dependencies


### PR DESCRIPTION
# Summary
<!--- Provide a general summary of the changes -->
We forgot to start zenoh inside the pixi env in CI.

## Proposed changes
<!--- Describe your changes and why they are necessary. -->

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
Closes #883 

## Checklist

- [X] Run `pixi run build`
- [ ] Write documentation
- [X] Test on your machine
- [ ] Test on the robot
- [ ] Create issues for future work
- [X] Triage this PR and label it
