### PR TITLE
Handle localisation after in-place penalties

### DIFF
--- a/src/bitbots_behavior/bitbots_blackboard/bitbots_blackboard/capsules/game_status_capsule.py
+++ b/src/bitbots_behavior/bitbots_blackboard/bitbots_blackboard/capsules/game_status_capsule.py
@@ -84,6 +84,9 @@ class GameStatusCapsule(AbstractBlackboardCapsule):
 
     def get_is_penalized(self) -> bool:
         return self.gamestate.penalized
+    
+    def get_is_penalized_in_place(self) -> bool:
+        return self.gamestate.penalized_in_place
 
     def received_gamestate(self) -> bool:
         return self.last_update != 0.0

--- a/src/bitbots_behavior/bitbots_blackboard/bitbots_blackboard/capsules/game_status_capsule.py
+++ b/src/bitbots_behavior/bitbots_blackboard/bitbots_blackboard/capsules/game_status_capsule.py
@@ -84,7 +84,7 @@ class GameStatusCapsule(AbstractBlackboardCapsule):
 
     def get_is_penalized(self) -> bool:
         return self.gamestate.penalized
-    
+
     def get_is_penalized_in_place(self) -> bool:
         return self.gamestate.penalized_in_place
 

--- a/src/bitbots_behavior/bitbots_blackboard/bitbots_blackboard/capsules/game_status_capsule.py
+++ b/src/bitbots_behavior/bitbots_blackboard/bitbots_blackboard/capsules/game_status_capsule.py
@@ -89,7 +89,7 @@ class GameStatusCapsule(AbstractBlackboardCapsule):
     def get_is_penalized_in_place(self) -> bool:
         return self.gamestate.penalized_in_place
 
-    def last_penalty_was_in_place(self) -> bool:
+    def get_last_penalty_was_in_place(self) -> bool:
         return self.last_penalty_was_in_place
 
     def received_gamestate(self) -> bool:

--- a/src/bitbots_behavior/bitbots_blackboard/bitbots_blackboard/capsules/game_status_capsule.py
+++ b/src/bitbots_behavior/bitbots_blackboard/bitbots_blackboard/capsules/game_status_capsule.py
@@ -88,7 +88,7 @@ class GameStatusCapsule(AbstractBlackboardCapsule):
 
     def get_is_penalized_in_place(self) -> bool:
         return self.gamestate.penalized_in_place
-    
+
     def last_penalty_was_in_place(self) -> bool:
         return self.last_penalty_was_in_place
 

--- a/src/bitbots_behavior/bitbots_blackboard/bitbots_blackboard/capsules/game_status_capsule.py
+++ b/src/bitbots_behavior/bitbots_blackboard/bitbots_blackboard/capsules/game_status_capsule.py
@@ -17,6 +17,7 @@ class GameStatusCapsule(AbstractBlackboardCapsule):
         self.gamestate = GameState()
         self.last_update: float = 0.0
         self.unpenalized_time: float = 0.0
+        self.last_penalty_was_in_place: bool = False
         self.last_goal_from_us_time = -86400.0
         self.last_goal_time = -86400.0
         self.free_kick_kickoff_team: bool | None = None
@@ -87,6 +88,9 @@ class GameStatusCapsule(AbstractBlackboardCapsule):
 
     def get_is_penalized_in_place(self) -> bool:
         return self.gamestate.penalized_in_place
+    
+    def last_penalty_was_in_place(self) -> bool:
+        return self.last_penalty_was_in_place
 
     def received_gamestate(self) -> bool:
         return self.last_update != 0.0
@@ -97,6 +101,7 @@ class GameStatusCapsule(AbstractBlackboardCapsule):
     def gamestate_callback(self, gamestate_msg: GameState) -> None:
         if self.gamestate.penalized and not gamestate_msg.penalized:
             self.unpenalized_time = self._node.get_clock().now().nanoseconds / 1e9
+            self.last_penalty_was_in_place = self.gamestate.penalized_in_place
 
         if gamestate_msg.own_score > self.gamestate.own_score:
             self.last_goal_from_us_time = self._node.get_clock().now().nanoseconds / 1e9

--- a/src/bitbots_navigation/bitbots_localization_handler/bitbots_localization_handler/localization_dsd/decisions/game_state.py
+++ b/src/bitbots_navigation/bitbots_localization_handler/bitbots_localization_handler/localization_dsd/decisions/game_state.py
@@ -148,7 +148,10 @@ class CheckPenalized(AbstractLocalizationDecisionElement):
                 return "PENALIZED_IN_PLACE"
             else:
                 return "YES"
-        elif self.blackboard.gamestate.get_seconds_since_unpenalized() < 1 and not self.blackboard.gamestate.last_penalty_was_in_place:
+        elif (
+            self.blackboard.gamestate.get_seconds_since_unpenalized() < 1
+            and not self.blackboard.gamestate.last_penalty_was_in_place
+        ):
             self.publish_debug_data("Reason", "Just unpenalized")
             return "JUST_UNPENALIZED"
         else:

--- a/src/bitbots_navigation/bitbots_localization_handler/bitbots_localization_handler/localization_dsd/decisions/game_state.py
+++ b/src/bitbots_navigation/bitbots_localization_handler/bitbots_localization_handler/localization_dsd/decisions/game_state.py
@@ -142,7 +142,7 @@ class CheckPenalized(AbstractLocalizationDecisionElement):
         Determines if the robot is penalized by the game controller.
         """
         self.publish_debug_data("Seconds since unpenalized", self.blackboard.gamestate.get_seconds_since_unpenalized())
-        self.publish_debug_data("Last penalty was in place", self.blackboard.gamestate.last_penalty_was_in_place)
+        self.publish_debug_data("Last penalty was in place", self.blackboard.gamestate.get_last_penalty_was_in_place())
         if self.blackboard.gamestate.get_is_penalized():
             if self.blackboard.gamestate.get_is_penalized_in_place():
                 return "PENALIZED_IN_PLACE"
@@ -150,7 +150,7 @@ class CheckPenalized(AbstractLocalizationDecisionElement):
                 return "YES"
         elif (
             self.blackboard.gamestate.get_seconds_since_unpenalized() < 1
-            and not self.blackboard.gamestate.last_penalty_was_in_place
+            and not self.blackboard.gamestate.get_last_penalty_was_in_place()
         ):
             self.publish_debug_data("Reason", "Just unpenalized")
             return "JUST_UNPENALIZED"

--- a/src/bitbots_navigation/bitbots_localization_handler/bitbots_localization_handler/localization_dsd/decisions/game_state.py
+++ b/src/bitbots_navigation/bitbots_localization_handler/bitbots_localization_handler/localization_dsd/decisions/game_state.py
@@ -142,6 +142,7 @@ class CheckPenalized(AbstractLocalizationDecisionElement):
         Determines if the robot is penalized by the game controller.
         """
         self.publish_debug_data("Seconds since unpenalized", self.blackboard.gamestate.get_seconds_since_unpenalized())
+        self.publish_debug_data("Last penalty was in place", self.blackboard.gamestate.last_penalty_was_in_place())
         if self.blackboard.gamestate.get_is_penalized():
             if self.blackboard.gamestate.get_is_penalized_in_place():
                 return "PENALIZED_IN_PLACE"

--- a/src/bitbots_navigation/bitbots_localization_handler/bitbots_localization_handler/localization_dsd/decisions/game_state.py
+++ b/src/bitbots_navigation/bitbots_localization_handler/bitbots_localization_handler/localization_dsd/decisions/game_state.py
@@ -142,13 +142,13 @@ class CheckPenalized(AbstractLocalizationDecisionElement):
         Determines if the robot is penalized by the game controller.
         """
         self.publish_debug_data("Seconds since unpenalized", self.blackboard.gamestate.get_seconds_since_unpenalized())
-        self.publish_debug_data("Last penalty was in place", self.blackboard.gamestate.last_penalty_was_in_place())
+        self.publish_debug_data("Last penalty was in place", self.blackboard.gamestate.last_penalty_was_in_place)
         if self.blackboard.gamestate.get_is_penalized():
             if self.blackboard.gamestate.get_is_penalized_in_place():
                 return "PENALIZED_IN_PLACE"
             else:
                 return "YES"
-        elif self.blackboard.gamestate.get_seconds_since_unpenalized() < 1 and not self.blackboard.gamestate.last_penalty_was_in_place():
+        elif self.blackboard.gamestate.get_seconds_since_unpenalized() < 1 and not self.blackboard.gamestate.last_penalty_was_in_place:
             self.publish_debug_data("Reason", "Just unpenalized")
             return "JUST_UNPENALIZED"
         else:

--- a/src/bitbots_navigation/bitbots_localization_handler/bitbots_localization_handler/localization_dsd/decisions/game_state.py
+++ b/src/bitbots_navigation/bitbots_localization_handler/bitbots_localization_handler/localization_dsd/decisions/game_state.py
@@ -147,7 +147,7 @@ class CheckPenalized(AbstractLocalizationDecisionElement):
                 return "PENALIZED_IN_PLACE"
             else:
                 return "YES"
-        elif self.blackboard.gamestate.get_seconds_since_unpenalized() < 1:
+        elif self.blackboard.gamestate.get_seconds_since_unpenalized() < 1 and not self.blackboard.gamestate.last_penalty_was_in_place():
             self.publish_debug_data("Reason", "Just unpenalized")
             return "JUST_UNPENALIZED"
         else:

--- a/src/bitbots_navigation/bitbots_localization_handler/bitbots_localization_handler/localization_dsd/decisions/game_state.py
+++ b/src/bitbots_navigation/bitbots_localization_handler/bitbots_localization_handler/localization_dsd/decisions/game_state.py
@@ -143,7 +143,10 @@ class CheckPenalized(AbstractLocalizationDecisionElement):
         """
         self.publish_debug_data("Seconds since unpenalized", self.blackboard.gamestate.get_seconds_since_unpenalized())
         if self.blackboard.gamestate.get_is_penalized():
-            return "YES"
+            if self.blackboard.gamestate.get_is_penalized_in_place():
+                return "PENALIZED_IN_PLACE"
+            else:
+                return "YES"
         elif self.blackboard.gamestate.get_seconds_since_unpenalized() < 1:
             self.publish_debug_data("Reason", "Just unpenalized")
             return "JUST_UNPENALIZED"

--- a/src/bitbots_navigation/bitbots_localization_handler/bitbots_localization_handler/localization_dsd/localization.dsd
+++ b/src/bitbots_navigation/bitbots_localization_handler/bitbots_localization_handler/localization_dsd/localization.dsd
@@ -17,6 +17,7 @@ $GettingUpState
         GAMESTATE_RECEIVED --> $CheckPenalized
             YES --> @LocalizationStop, @DoNothing
             JUST_UNPENALIZED --> @InitSide, @LocalizationStart, @DoNothing
+            PENALIZED_IN_PLACE --> @DoNothing
             NO --> $InitialToReady
                 YES --> @InitSide, @DoNothing
                 NO --> $GameStateDecider

--- a/src/lib/game_controller_hsl/game_controller_hsl/game_controller_hsl/receiver.py
+++ b/src/lib/game_controller_hsl/game_controller_hsl/game_controller_hsl/receiver.py
@@ -239,6 +239,8 @@ class GameStateReceiver(Node):
             secs_remaining=state.secs_remaining,
             secondary_time=state.secondary_time,
             penalized=this_robot.penalty != 0,
+            #2 is the motion in set penalty
+            penalized_in_place=this_robot.penalty == 2,
             seconds_till_unpenalized=this_robot.secs_till_unpenalized,
             warings=this_robot.warnings,
             cautions=this_robot.cautions,

--- a/src/lib/game_controller_hsl/game_controller_hsl/scripts/sim_gamestate.py
+++ b/src/lib/game_controller_hsl/game_controller_hsl/scripts/sim_gamestate.py
@@ -158,6 +158,7 @@ Main State:         {game_state_msg.main_state}
 Kicking Team:       {game_state_msg.kicking_team}
 
 Penalized:          {game_state_msg.penalized}
+In Place Penalized: {game_state_msg.penalized_in_place}
 Stopped:            {game_state_msg.stopped}
 
 Goals(Own : Rival): {game_state_msg.own_score} : {game_state_msg.rival_score}

--- a/src/lib/game_controller_hsl/game_controller_hsl/scripts/sim_gamestate.py
+++ b/src/lib/game_controller_hsl/game_controller_hsl/scripts/sim_gamestate.py
@@ -47,6 +47,7 @@ j: SET_PLAY_GOAL_KICK = 5
 k: SET_PLAY_CORNER_KICK = 6
 
 p:     toggle penalized
+l:     toggle in place penalty
 t:     toggle kicking team
 s:     toggle stopped state
 +:     increase own score by 1
@@ -111,6 +112,9 @@ CTRL-C to quit
                     int_key = int(key)
                     game_state_msg.competition_type = int_key - 5
                 elif key == "p":  # penalize / unpenalize
+                    game_state_msg.penalized = not game_state_msg.penalized
+                elif key == "l":  # toggle in place penalty
+                    game_state_msg.penalized_in_place = not game_state_msg.penalized_in_place
                     game_state_msg.penalized = not game_state_msg.penalized
                 elif key in [chr(ord("a") + x) for x in range(4)]:
                     game_state_msg.game_phase = ord(key) - ord("a")

--- a/src/lib/game_controller_hsl/game_controller_hsl_interfaces/msg/GameState.msg
+++ b/src/lib/game_controller_hsl/game_controller_hsl_interfaces/msg/GameState.msg
@@ -45,6 +45,7 @@ int16 secs_remaining
 # Seconds remaining for things like kickoff
 int16 secondary_time
 bool penalized
+bool penalized_in_place
 uint16 seconds_till_unpenalized
 uint8 warnings
 uint8 cautions


### PR DESCRIPTION
# Summary
<!--- Provide a general summary of the changes -->
In case of a in place penalty we don't want to reset the localisation to the field size, therefore we check in the gameState message for the penalty type and integrate it in the decisions of the localisation.dsd

## Checklist

- [ ] Run `pixi run build`
- [ ] Write documentation
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Create issues for future work
- [ ] Triage this PR and label it
