### PR TITLE
Render MuJoCo cameras via EGL when running the headless web viewer

### DIFF
--- a/src/bitbots_simulation/bitbots_mujoco_sim/launch/simulator.launch
+++ b/src/bitbots_simulation/bitbots_mujoco_sim/launch/simulator.launch
@@ -1,5 +1,9 @@
 <launch>
   <arg name="web" default="false" description="Use web-based mjviser viewer instead of the native MuJoCo viewer"/>
+
+  <!-- The web viewer runs headless (no X server), so MuJoCo needs to render the cameras via EGL instead of GLFW -->
+  <set_env name="MUJOCO_GL" value="egl" if="$(var web)"/>
+
   <node pkg="bitbots_mujoco_sim" exec="sim" name="sim_interface" output="screen">
     <param name="use_namespace" value="false"/>
     <param name="web" value="$(var web)"/>


### PR DESCRIPTION
The web viewer (mjviser) runs without an X server, but mujoco.Renderer still defaults to GLFW for the camera sensors, which fails without a display. Set MUJOCO_GL=egl for that case so the cameras render headlessly.

