### PR TITLE
Drop from WALKING to CONTROLLABLE when walk output has no significant motion

### DIFF
--- a/src/bitbots_motion/bitbots_hcm/bitbots_hcm/hcm_dsd/decisions/walking.py
+++ b/src/bitbots_motion/bitbots_hcm/bitbots_hcm/hcm_dsd/decisions/walking.py
@@ -4,12 +4,6 @@ from bitbots_hcm.hcm_dsd.decisions import AbstractHCMDecisionElement
 class RecentWalkingGoals(AbstractHCMDecisionElement):
     """
     Decides if the robot is currently walking or just balancing in place.
-
-    Returns STAY_WALKING when the walk node is active and any joint moved more
-    than 3° relative to the previous walk command within standing_transition_delay.
-    Returns NOT_WALKING (→ CONTROLLABLE) when the walk node stopped or has been
-    sending only small corrections for longer than standing_transition_delay.
-    The walk node continues to run and balance in CONTROLLABLE state.
     """
 
     def perform(self, reevaluate=False):

--- a/src/bitbots_motion/bitbots_hcm/bitbots_hcm/hcm_dsd/decisions/walking.py
+++ b/src/bitbots_motion/bitbots_hcm/bitbots_hcm/hcm_dsd/decisions/walking.py
@@ -3,26 +3,37 @@ from bitbots_hcm.hcm_dsd.decisions import AbstractHCMDecisionElement
 
 class RecentWalkingGoals(AbstractHCMDecisionElement):
     """
-    Decides if the robot is currently getting joint commands to from the walking node
+    Decides if the robot is currently walking or just balancing in place.
+
+    Returns STAY_WALKING when the walk node is active and any joint moved more
+    than 3° relative to the previous walk command within standing_transition_delay.
+    Returns NOT_WALKING (→ CONTROLLABLE) when the walk node stopped or has been
+    sending only small corrections for longer than standing_transition_delay.
+    The walk node continues to run and balance in CONTROLLABLE state.
     """
 
     def perform(self, reevaluate=False):
-        # Check if we have received a walking goal at all
+        now = self.blackboard.node.get_clock().now().nanoseconds / 1e9
+
+        # Walk node has never sent goals → not walking
         if self.blackboard.last_walking_goal_time is None:
             return "NOT_WALKING"
 
-        # Calculate the time delta between now and the last walking goal
-        time_delta = (
-            self.blackboard.node.get_clock().now().nanoseconds / 1e9
-            - self.blackboard.last_walking_goal_time.nanoseconds / 1e9
-        )
+        time_since_walk_goal = now - self.blackboard.last_walking_goal_time.nanoseconds / 1e9
+        self.publish_debug_data("Last Walking Goal Time Delta", time_since_walk_goal)
 
-        # Log the time delta between now and the last walking goal
-        self.publish_debug_data("Last Walking Goal Time Delta", time_delta)
+        # Walk node stopped entirely → not walking
+        if time_since_walk_goal >= 0.1:
+            return "NOT_WALKING"
 
-        # If the time delta is smaller enough, we are still walking
-        if time_delta < 0.1:
-            # we are walking and can stay like this
+        # Walk node is active — check whether significant motion was commanded recently
+        if self.blackboard.last_significant_walk_motion_time is None:
+            return "NOT_WALKING"
+
+        time_since_motion = now - self.blackboard.last_significant_walk_motion_time.nanoseconds / 1e9
+        self.publish_debug_data("Time Since Significant Walk Motion", time_since_motion)
+
+        if time_since_motion < self.blackboard.standing_transition_delay:
             return "STAY_WALKING"
         else:
             return "NOT_WALKING"

--- a/src/bitbots_motion/bitbots_hcm/bitbots_hcm/hcm_dsd/hcm_blackboard.py
+++ b/src/bitbots_motion/bitbots_hcm/bitbots_hcm/hcm_dsd/hcm_blackboard.py
@@ -92,6 +92,10 @@ class HcmBlackboard:
 
         # Walking state
         self.last_walking_goal_time: Optional[Time] = None
+        # Time of the last walk motor goal that deviated >3° from the previous walk command
+        self.last_significant_walk_motion_time: Optional[Time] = None
+        # Seconds without significant walk motion before dropping from WALKING to CONTROLLABLE
+        self.standing_transition_delay: float = self.node.get_parameter("standing_transition_delay").value
 
         # Falling
         # Parameters

--- a/src/bitbots_motion/bitbots_hcm/bitbots_hcm/hcm_dsd/hcm_blackboard.py
+++ b/src/bitbots_motion/bitbots_hcm/bitbots_hcm/hcm_dsd/hcm_blackboard.py
@@ -92,7 +92,7 @@ class HcmBlackboard:
 
         # Walking state
         self.last_walking_goal_time: Optional[Time] = None
-        # Time of the last walk motor goal that deviated >3° from the previous walk command
+        # Time of the last walk motor goal that deviated significantly
         self.last_significant_walk_motion_time: Optional[Time] = None
         # Seconds without significant walk motion before dropping from WALKING to CONTROLLABLE
         self.standing_transition_delay: float = self.node.get_parameter("standing_transition_delay").value

--- a/src/bitbots_motion/bitbots_hcm/bitbots_hcm/humanoid_control_module.py
+++ b/src/bitbots_motion/bitbots_hcm/bitbots_hcm/humanoid_control_module.py
@@ -238,6 +238,11 @@ class HardwareControlManager:
     def set_last_walking_goal_time(self, time_msg_serialized: bytes):
         self.blackboard.last_walking_goal_time = Time.from_msg(deserialize_message(time_msg_serialized, TimeMsg))
 
+    def set_last_significant_walk_motion_time(self, time_msg_serialized: bytes):
+        self.blackboard.last_significant_walk_motion_time = Time.from_msg(
+            deserialize_message(time_msg_serialized, TimeMsg)
+        )
+
     def set_last_kick_goal_time(self, time_msg_serialized: bytes):
         self.blackboard.last_kick_goal_time = Time.from_msg(deserialize_message(time_msg_serialized, TimeMsg))
 

--- a/src/bitbots_motion/bitbots_hcm/config/hcm_piplus.yaml
+++ b/src/bitbots_motion/bitbots_hcm/config/hcm_piplus.yaml
@@ -8,6 +8,7 @@
 
     # Motors
     motor_off_time: 30000000.0 # time of no use or updates when the hcm goes to soft off
+    standing_transition_delay: 1.0 # seconds without significant walk motion before transitioning from WALKING to CONTROLLABLE
     motor_timeout_duration: 0.5 # time without messages from the servos till error is produced [s]
 
     # Animations

--- a/src/bitbots_motion/bitbots_hcm/src/hcm.cpp
+++ b/src/bitbots_motion/bitbots_hcm/src/hcm.cpp
@@ -100,11 +100,10 @@ class HCM_CPP : public rclcpp::Node {
   void walking_goal_callback(bitbots_msgs::msg::JointCommand msg) {
     last_walking_time_ = msg.header.stamp;
 
-    // Detect significant motion: any joint moved >3° relative to the previous walk command
+    // Detect significant motion: any joint moved more than the threshold relative to the previous walk command
     if (last_walk_command_ && msg.positions.size() == last_walk_command_->positions.size()) {
-      constexpr double kSignificantMotionThreshold = 3.0 * M_PI / 180.0;
       for (size_t i = 0; i < msg.positions.size(); ++i) {
-        if (std::abs(msg.positions[i] - last_walk_command_->positions[i]) > kSignificantMotionThreshold) {
+        if (std::abs(msg.positions[i] - last_walk_command_->positions[i]) > significant_motion_threshold_) {
           last_significant_walk_motion_time_ = msg.header.stamp;
           break;
         }
@@ -172,6 +171,7 @@ class HCM_CPP : public rclcpp::Node {
   std::optional<sensor_msgs::msg::JointState> current_joint_state_;
 
   // Walking state
+  double significant_motion_threshold_ = 0.5 * M_PI / 180.0;  // default to 0.5 degrees in radians
   std::optional<builtin_interfaces::msg::Time> last_walking_time_;
   std::optional<builtin_interfaces::msg::Time> last_significant_walk_motion_time_;
   std::optional<bitbots_msgs::msg::JointCommand> last_walk_command_;

--- a/src/bitbots_motion/bitbots_hcm/src/hcm.cpp
+++ b/src/bitbots_motion/bitbots_hcm/src/hcm.cpp
@@ -99,6 +99,19 @@ class HCM_CPP : public rclcpp::Node {
 
   void walking_goal_callback(bitbots_msgs::msg::JointCommand msg) {
     last_walking_time_ = msg.header.stamp;
+
+    // Detect significant motion: any joint moved >3° relative to the previous walk command
+    if (last_walk_command_ && msg.positions.size() == last_walk_command_->positions.size()) {
+      constexpr double kSignificantMotionThreshold = 3.0 * M_PI / 180.0;
+      for (size_t i = 0; i < msg.positions.size(); ++i) {
+        if (std::abs(msg.positions[i] - last_walk_command_->positions[i]) > kSignificantMotionThreshold) {
+          last_significant_walk_motion_time_ = msg.header.stamp;
+          break;
+        }
+      }
+    }
+    last_walk_command_ = msg;
+
     if (current_state_ == bitbots_msgs::msg::RobotControlState::CONTROLLABLE ||
         current_state_ == bitbots_msgs::msg::RobotControlState::WALKING) {
       pub_controller_command_->publish(msg);
@@ -122,6 +135,10 @@ class HCM_CPP : public rclcpp::Node {
     if (last_walking_time_) {
       hcm_py_.attr("set_last_walking_goal_time")(
           ros2_python_extension::toPython<builtin_interfaces::msg::Time>(last_walking_time_.value()));
+    }
+    if (last_significant_walk_motion_time_) {
+      hcm_py_.attr("set_last_significant_walk_motion_time")(
+          ros2_python_extension::toPython<builtin_interfaces::msg::Time>(last_significant_walk_motion_time_.value()));
     }
     if (last_animation_goal_time_) {
       hcm_py_.attr("set_last_animation_goal_time")(
@@ -156,6 +173,8 @@ class HCM_CPP : public rclcpp::Node {
 
   // Walking state
   std::optional<builtin_interfaces::msg::Time> last_walking_time_;
+  std::optional<builtin_interfaces::msg::Time> last_significant_walk_motion_time_;
+  std::optional<bitbots_msgs::msg::JointCommand> last_walk_command_;
 
   // Animation states
   std::optional<builtin_interfaces::msg::Time> last_animation_goal_time_;


### PR DESCRIPTION
Tracks the last time any walk joint command deviated >3° from the previous
walk command. After standing_transition_delay seconds without such motion,
the HCM drops to CONTROLLABLE so animations can run while the walk node
continues balancing until the animation is requested. Significant motion (e.g. capture steps) immediately
returns the state to WALKING from CONTROLLABLE.

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
Closes #881

## Checklist

- [x] Run `pixi run build`
- [x] Write documentation
- [x] Test on your machine
- [x] Test on the robot
- [x] Create issues for future work
- [x] Triage this PR and label it
