### PR TITLE
remove warnings field in game controller communication

### DIFF
--- a/src/lib/game_controller_hsl/game_controller_hsl/game_controller_hsl/gamestate.py
+++ b/src/lib/game_controller_hsl/game_controller_hsl/game_controller_hsl/gamestate.py
@@ -56,7 +56,7 @@ TeamInfoStruct = "team" / Struct(
     "players" / Array(20, RobotInfoStruct) #always eleven fine?
 )
 
-GAME_CONTROLLER_RESPONSE_VERSION = 19
+GAME_CONTROLLER_RESPONSE_VERSION = 20
 
 GameStateStruct = "gamedata" / Struct(
     "header" / Const(b'RGme'),

--- a/src/lib/game_controller_hsl/game_controller_hsl/game_controller_hsl/gamestate.py
+++ b/src/lib/game_controller_hsl/game_controller_hsl/game_controller_hsl/gamestate.py
@@ -17,7 +17,6 @@ RobotInfoStruct = "robot_info" / Struct(
     # define MANUAL                      15
     "penalty" / Byte,
     "secs_till_unpenalized" / Byte,
-    "warnings" / Byte,
     "cautions" / Byte,
     #"number_of_red_cards" / Byte,
     #"goalkeeper" / Flag

--- a/src/lib/game_controller_hsl/game_controller_hsl/game_controller_hsl/receiver.py
+++ b/src/lib/game_controller_hsl/game_controller_hsl/game_controller_hsl/receiver.py
@@ -242,7 +242,6 @@ class GameStateReceiver(Node):
             #2 is the motion in set penalty
             penalized_in_place=this_robot.penalty == 2,
             seconds_till_unpenalized=this_robot.secs_till_unpenalized,
-            warings=this_robot.warnings,
             cautions=this_robot.cautions,
             own_player_color=own_team.field_player_color.intvalue,
             own_goalie_color=own_team.goalkeeper_color.intvalue,

--- a/src/lib/game_controller_hsl/game_controller_hsl_interfaces/msg/GameState.msg
+++ b/src/lib/game_controller_hsl/game_controller_hsl_interfaces/msg/GameState.msg
@@ -47,7 +47,6 @@ int16 secondary_time
 bool penalized
 bool penalized_in_place
 uint16 seconds_till_unpenalized
-uint8 warnings
 uint8 cautions
 
 uint8 TEAM_BLUE = 0


### PR DESCRIPTION
# Summary
<!--- Provide a general summary of the changes -->
Warnings are no longer part of the game controller message (version 20)

## Proposed changes
<!--- Describe your changes and why they are necessary. -->
remove warning fields to avoid parse errors

## Checklist

- [ ] Run `pixi run build`
- [ ] Write documentation
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Create issues for future work
- [ ] Triage this PR and label it
