### PR TITLE
change supporter role to def or blocking

### DIFF
--- a/src/bitbots_behavior/bitbots_body_behavior/bitbots_body_behavior/behavior_dsd/decisions/sceond_ball_touch_allowed.py
+++ b/src/bitbots_behavior/bitbots_body_behavior/bitbots_body_behavior/behavior_dsd/decisions/sceond_ball_touch_allowed.py
@@ -48,7 +48,7 @@ class SecondBallTouchAllowed(AbstractDecisionElement):
             self.latch = False
             self.latch_start_time = None
             return "YES"
-        elif self.latch and duration_since_latch > 20.0:  # Latch for x seconds
+        elif self.latch and duration_since_latch > 8.0:  # Latch for x seconds
             self.latch = False
             self.latch_start_time = None
             return "YES"

--- a/src/bitbots_behavior/bitbots_body_behavior/bitbots_body_behavior/behavior_dsd/main.dsd
+++ b/src/bitbots_behavior/bitbots_body_behavior/bitbots_body_behavior/behavior_dsd/main.dsd
@@ -106,7 +106,9 @@ $DoOnce
 
 #NormalBehavior
 $SecondBallTouchAllowed
-    NO --> @SetNoSecondBallContactVariable + value:false + r:false, @LookAtFieldFeatures + r:false, @ChangeAction + action:passive + r:false, @AvoidBallActive + r:false, @GoToPassPreparePosition + blocking:true 
+    NO --> $ConfigRole
+        GOALIE --> @SetNoSecondBallContactVariable + value:false + r:false, @LookAtFieldFeatures + r:false, @ChangeAction + action:passive + r:false, @AvoidBallActive + r:false, @GoToBlockPosition
+        ELSE --> @SetNoSecondBallContactVariable + value:false + r:false, @LookAtFieldFeatures + r:false, @ChangeAction + action:passive + r:false, @AvoidBallActive + r:false, @GoToDefensePosition
     YES --> $BallSeen
         NO --> $ConfigRole
             GOALIE --> #RolePositionWithPause


### PR DESCRIPTION
# Summary
Actual situation after set play kick with double touch -> passiv player at special supporter position, second to ball striker, third supporter 

## Proposed changes
Move the passiv player back to def or blocking pos, depending on goalie role


## Checklist

- [ ] Run `pixi run build`
- [ ] Write documentation
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Create issues for future work
- [ ] Triage this PR and label it
