### PR TITLE
Go to action kicking while dribbeling so that we can detect it

### DIFF
--- a/src/bitbots_behavior/bitbots_body_behavior/bitbots_body_behavior/behavior_dsd/main.dsd
+++ b/src/bitbots_behavior/bitbots_body_behavior/bitbots_body_behavior/behavior_dsd/main.dsd
@@ -21,7 +21,7 @@ $DoOnce
 @ChangeAction + action:waiting + r:false, @PlayAnimationInitInSim + r:false, @LookAtFieldFeatures + r:false, @WalkInPlace
 
 #Dribble
-@ChangeAction + action:going_to_ball, @CancelPathplanning, @LookAtFront, @DribbleForward
+@ChangeAction + action:kicking, @CancelPathplanning, @LookAtFront, @DribbleForward
 
 #RolePositionWithPause
 $DoOnce


### PR DESCRIPTION
# Summary
<!--- Provide a general summary of the changes -->
The double touch behavior depends on teammates signalling that they are kicking. This PR changes the dribbling behavior so that we actually do that.

## Proposed changes
<!--- Describe your changes and why they are necessary. -->

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce. -->

## Checklist

- [ ] Run `pixi run build`
- [ ] Write documentation
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Create issues for future work
- [ ] Triage this PR and label it
