### PR TITLE
Fix rl_motion node not using sim time

### DIFF
--- a/src/bitbots_motion/bitbots_rl_motion/launch/rl_motion.launch
+++ b/src/bitbots_motion/bitbots_rl_motion/launch/rl_motion.launch
@@ -8,17 +8,20 @@
   <group if="$(var walk)">
     <node pkg="bitbots_rl_motion" exec="walk_node" output="screen">
       <param from="$(find-pkg-share bitbots_rl_motion)/configs/playground_walk_model.yaml" />
+      <param name="use_sim_time" value="$(var sim)"/>
     </node>
   </group>
 
   <group if="$(var kick)">
     <node pkg="bitbots_rl_motion" exec="kick_node" output="screen">
       <param from="$(find-pkg-share bitbots_rl_motion)/configs/wolfgang_dribbling_model_config.yaml" />
+      <param name="use_sim_time" value="$(var sim)"/>
     </node>
   </group>
   <group if="$(var mjlab_walk)">
     <node pkg="bitbots_rl_motion" exec="mjlab_walk_node" output="screen">
       <param from="$(find-pkg-share bitbots_rl_motion)/configs/mjlab_walk_model.yaml" />
+      <param name="use_sim_time" value="$(var sim)"/>
     </node>
   </group>
 </launch>


### PR DESCRIPTION
# Summary
<!--- Provide a general summary of the changes -->
This is extracted from #930. The node currently uses realtime which leads to bad behavior when running at a lower (or higher) realtime factor.
## Proposed changes
<!--- Describe your changes and why they are necessary. -->

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce. -->

## Checklist

- [ ] Run `pixi run build`
- [ ] Write documentation
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Create issues for future work
- [ ] Triage this PR and label it
