### PR TITLE
Add supporter_min_x and make both parameters relative

### DIFF
--- a/src/bitbots_behavior/bitbots_body_behavior/bitbots_body_behavior/behavior_dsd/actions/go_to_pass_position.py
+++ b/src/bitbots_behavior/bitbots_body_behavior/bitbots_body_behavior/behavior_dsd/actions/go_to_pass_position.py
@@ -9,7 +9,8 @@ class AbstractGoToPassPosition(AbstractActionElement):
 
     def __init__(self, blackboard, dsd, accept, parameters):
         super().__init__(blackboard, dsd, parameters)
-        self.max_x = self.blackboard.config["supporter_max_x"]
+        self.max_x = self.blackboard.config["supporter_max_x"] * self.blackboard.world_model.field_length / 2
+        self.min_x = self.blackboard.config["supporter_min_x"] * self.blackboard.world_model.field_length / 2
         self.pass_pos_x = self.blackboard.config["pass_position_x"]
         self.pass_pos_y = self.blackboard.config["pass_position_y"]
         self.accept = accept
@@ -26,7 +27,7 @@ class AbstractGoToPassPosition(AbstractActionElement):
             goal_x += self.pass_pos_x
 
         # Limit the x position, so that we are not running into the enemy goal
-        goal_x = min(self.max_x, goal_x)
+        goal_x = min(self.max_x, max(self.min_x, goal_x))
 
         # Calculate the two possible y positions for the pass position
         goal_y_options = [ball_pos[1] + self.pass_pos_y, ball_pos[1] - self.pass_pos_y]

--- a/src/bitbots_behavior/bitbots_body_behavior/config/body_behavior.yaml
+++ b/src/bitbots_behavior/bitbots_body_behavior/config/body_behavior.yaml
@@ -121,7 +121,8 @@ body_behavior:
     # The position where the supporter robot should place itself in order to accept a pass
     pass_position_x: -0.2
     pass_position_y: 0.8
-    supporter_max_x: 4.0
+    supporter_max_x: 1.0 # Relative to the field length / 2
+    supporter_min_x: -0.9 # Relative to the field length / 2
     supporter_max_y: 2.0
     supporter_min_y: -2.0
 


### PR DESCRIPTION
# Summary
<!--- Provide a general summary of the changes -->

Since the supporter position may now be used very close to the goal, we need to keep it away from the goal line such that it doesn't get caught in the net or similar.

## Proposed changes
<!--- Describe your changes and why they are necessary. -->
Add a supporter_min_x parameter. At the same time we also noticed that the max_x was an absolute value despite it probably being supposed to match the field length, meaning depending on the field we may have issues. @Flova Input on this would be nice.

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce. -->

## Checklist

- [ ] Run `pixi run build`
- [ ] Write documentation
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Create issues for future work
- [ ] Triage this PR and label it
