### PR TITLE
Feature/head collision

### DIFF
--- a/src/bitbots_motion/bitbots_head_mover/src/move_head.cpp
+++ b/src/bitbots_motion/bitbots_head_mover/src/move_head.cpp
@@ -374,9 +374,9 @@ class HeadMover {
     // Checks whether head position is higher than torso.
     if (params_.max_pitch[0] < pitch && pitch < params_.max_pitch[1] && params_.max_yaw[0] < yaw &&
         yaw < params_.max_yaw[1]) {
-      return true;
+      return false;
     }
-    return false;
+    return true;
   }
 
   /**

--- a/src/bitbots_motion/bitbots_head_mover/src/move_head.cpp
+++ b/src/bitbots_motion/bitbots_head_mover/src/move_head.cpp
@@ -371,8 +371,11 @@ class HeadMover {
    * @brief Checks if the head collides with the body at a given yaw and pitch position
    */
   bool check_head_collision(double yaw, double pitch) {
-    // TODO we do not have a collision model for the pi plus head yet, so we need to implement this function properly
-    RCLCPP_ERROR_STREAM_THROTTLE(node_->get_logger(), *node_->get_clock(), 1000, "Do not have a collision model!");
+    // Checks whether head position is higher than torso.
+    if (params_.max_pitch[0] < pitch && pitch < params_.max_pitch[1] && params_.max_yaw[0] < yaw &&
+        yaw < params_.max_yaw[1]) {
+      return true;
+    }
     return false;
   }
 


### PR DESCRIPTION
# Summary
Head collisions are set pitch and yaw restrictions

## Proposed changes
Using head and yaw restrictions

## Related issues
Head moves full-speed right and touches torso when mode starts and no ball is detected (and hasn't been tracked).

## Checklist

- [x] Run `pixi run build`
- [ ] Test on your machine
- [x] Test on the robot
- [ ] Create issues for future work
- [ ] Triage this PR and label it
