### PR TITLE
Make Ball position provided to monitor relative to robot.

### DIFF
--- a/src/bitbots_misc/bitbots_player_state/bitbots_player_state/player_state_aggregator.py
+++ b/src/bitbots_misc/bitbots_player_state/bitbots_player_state/player_state_aggregator.py
@@ -1,12 +1,14 @@
 import rclpy
+from bitbots_tf_buffer import Buffer
 from game_controller_hsl_interfaces.msg import PlayerStateResponse
 from geometry_msgs.msg import PointStamped, PoseStamped, PoseWithCovarianceStamped
 from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
 from rclpy.experimental.events_executor import EventsExecutor
 from rclpy.node import Node
+from rclpy.duration import Duration
 
 from bitbots_msgs.msg import RobotControlState
-
+import tf2_geometry_msgs
 
 class PlayerStateAggregator(Node):
     """Aggregate native robot state into the GameController response interface."""
@@ -23,6 +25,7 @@ class PlayerStateAggregator(Node):
         robot_state_topic = self.declare_parameter("robot_state_topic", "robot_state").value
         pose_topic = self.declare_parameter("pose_topic", "pose_with_covariance").value
         ball_topic = self.declare_parameter("ball_topic", "ball_position_relative_filtered").value
+        self.ball_frame_out = self.declare_parameter("ball_frame_out", "base_footprint").value
         response_topic = self.declare_parameter("response_topic", "player_state_response").value
         publish_rate = self.declare_parameter("publish_rate", 1.0).value
 
@@ -32,6 +35,7 @@ class PlayerStateAggregator(Node):
         self._fallen = False
         self._pose: PoseStamped | None = None
         self._relative_ball: PointStamped | None = None
+        self._tf_buffer = Buffer(Duration(seconds=30), self)
 
         self._publisher = self.create_publisher(
             PlayerStateResponse, response_topic, 1, callback_group=MutuallyExclusiveCallbackGroup()
@@ -78,7 +82,10 @@ class PlayerStateAggregator(Node):
             response.pose = self._pose
 
         if self._relative_ball is not None:
-            response.ball = self._relative_ball
+            try:
+                response.ball = self._tf_buffer.transform(self._relative_ball, self.ball_frame_out)
+            except Exception as e:
+                pass
 
         return response
 

--- a/src/bitbots_misc/bitbots_player_state/bitbots_player_state/player_state_aggregator.py
+++ b/src/bitbots_misc/bitbots_player_state/bitbots_player_state/player_state_aggregator.py
@@ -1,14 +1,15 @@
 import rclpy
+import tf2_geometry_msgs  # noqa: F401
 from bitbots_tf_buffer import Buffer
 from game_controller_hsl_interfaces.msg import PlayerStateResponse
 from geometry_msgs.msg import PointStamped, PoseStamped, PoseWithCovarianceStamped
 from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
+from rclpy.duration import Duration
 from rclpy.experimental.events_executor import EventsExecutor
 from rclpy.node import Node
-from rclpy.duration import Duration
 
 from bitbots_msgs.msg import RobotControlState
-import tf2_geometry_msgs
+
 
 class PlayerStateAggregator(Node):
     """Aggregate native robot state into the GameController response interface."""
@@ -85,6 +86,7 @@ class PlayerStateAggregator(Node):
             try:
                 response.ball = self._tf_buffer.transform(self._relative_ball, self.ball_frame_out)
             except Exception as e:
+                self._node.get_logger().warn(str(e))
                 pass
 
         return response

--- a/src/bitbots_misc/bitbots_player_state/bitbots_player_state/player_state_aggregator.py
+++ b/src/bitbots_misc/bitbots_player_state/bitbots_player_state/player_state_aggregator.py
@@ -86,7 +86,7 @@ class PlayerStateAggregator(Node):
             try:
                 response.ball = self._tf_buffer.transform(self._relative_ball, self.ball_frame_out)
             except Exception as e:
-                self._node.get_logger().warn(str(e))
+                self.get_logger().warn(str(e), throttle_duration_sec=10.0)
                 pass
 
         return response

--- a/src/bitbots_misc/bitbots_player_state/test/test_player_state_aggregator.py
+++ b/src/bitbots_misc/bitbots_player_state/test/test_player_state_aggregator.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock
 import pytest
 from bitbots_player_state.player_state_aggregator import PlayerStateAggregator
 from builtin_interfaces.msg import Time
-from geometry_msgs.msg import Point, PoseWithCovarianceStamped, Quaternion
+from geometry_msgs.msg import Point, PointStamped, PoseWithCovarianceStamped, Quaternion
 from std_msgs.msg import Header
 
 from bitbots_msgs.msg import RobotControlState
@@ -17,9 +17,15 @@ def test_build_response_aggregates_latest_state(aggregator):
     pose.pose.pose.position.y = -2.0
     pose.pose.pose.orientation = Quaternion(w=1.0)
     ball = PoseWithCovarianceStamped(
-        header=Header(stamp=Time(sec=11), frame_id="base_footprint"),
+        header=Header(stamp=Time(sec=11), frame_id="odom"),
     )
     ball.pose.pose.position = Point(x=0.4, y=-0.2)
+
+    transformed_ball = PointStamped(
+        header=Header(stamp=Time(sec=11), frame_id="base_footprint"),
+        point=Point(x=0.1, y=0.3),
+    )
+    aggregator._tf_buffer.transform.return_value = transformed_ball
 
     aggregator._pose_callback(pose)
     aggregator._robot_state_callback(RobotControlState(state=RobotControlState.FALLEN))
@@ -27,12 +33,13 @@ def test_build_response_aggregates_latest_state(aggregator):
 
     response = aggregator.build_response()
 
+    aggregator._tf_buffer.transform.assert_called_once_with(aggregator._relative_ball, "base_footprint")
+    assert aggregator._relative_ball.header == Header(stamp=Time(sec=11), frame_id="odom")
     assert response.header == Header(stamp=Time(sec=12), frame_id="")
     assert response.fallen is True
     assert response.pose.header == Header(stamp=Time(sec=10), frame_id="map")
     assert response.pose.pose.position == Point(x=1.0, y=-2.0)
-    assert response.ball.header == Header(stamp=Time(sec=11), frame_id="base_footprint")
-    assert response.ball.point == Point(x=0.4, y=-0.2)
+    assert response.ball == transformed_ball
 
 
 @pytest.fixture
@@ -41,6 +48,8 @@ def aggregator():
     node._fallen = False
     node._pose = None
     node._relative_ball = None
+    node._tf_buffer = Mock()
+    node.ball_frame_out = "base_footprint"
     node._clock = Mock()
     node._clock.now.return_value.to_msg.return_value = Time(sec=12)
     return node


### PR DESCRIPTION
# Summary
<!--- Provide a general summary of the changes -->
Currently the ball position is provided in the odom frame, which is not useful.

## Proposed changes
<!--- Describe your changes and why they are necessary. -->

Add a transform buffer & transform the `/ball_pos_rel_filtered` into the base_footprint frame, which *should* be correct.

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce. -->

## Checklist

- [ ] Run `pixi run build`
- [ ] Write documentation
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Create issues for future work
- [ ] Triage this PR and label it
