### PR TITLE
Add increased rate for team comm when in kicking mode

### DIFF
--- a/src/bitbots_team_communication/bitbots_team_communication/bitbots_team_communication/bitbots_team_communication.py
+++ b/src/bitbots_team_communication/bitbots_team_communication/bitbots_team_communication/bitbots_team_communication.py
@@ -51,6 +51,8 @@ class TeamCommunication:
         self.socket_communication = SocketCommunication(self.node, self.logger, self.team_id, self.player_id)
 
         self.rate: int = self.node.get_parameter("rate").value
+        self.increase_kicking_rate: int = self.node.get_parameter("increase_kicking_rate").value
+        self.always_publish_during_kick: bool = self.node.get_parameter("always_publish_during_kick").value
         self.lifetime: int = self.node.get_parameter("lifetime").value
         self.max_message_size: int = self.node.get_parameter("max_message_size").value
         self.avg_walking_speed: float = self.node.get_parameter("avg_walking_speed").value
@@ -68,6 +70,10 @@ class TeamCommunication:
         self.run_spin_in_thread()
         self.try_to_establish_connection()
 
+        self.actual_rate = self.rate * self.increase_kicking_rate
+        self.counter = 0
+        self.last_action = None
+
         # See https://github.com/ros2/rclcpp/issues/2535
         # In sim, the builtin timers may not work correctly if there is a high load of callbacks
         # This can lead to breaks and bursts which is unacceptable for this usecase
@@ -76,15 +82,31 @@ class TeamCommunication:
             self.node.create_subscription(
                 Clock, "/clock", self.clock_cb, callback_group=MutuallyExclusiveCallbackGroup(), qos_profile=1
             )
-            self.next_send_time = self.node.get_clock().now() + Duration(seconds=1 / self.rate)
+            self.next_send_time = self.node.get_clock().now() + Duration(seconds=1 / self.actual_rate)
         else:
-            self.node.create_timer(1 / self.rate, self.send_message, callback_group=MutuallyExclusiveCallbackGroup())
+            self.node.create_timer(
+                1 / self.actual_rate, self.send_message, callback_group=MutuallyExclusiveCallbackGroup()
+            )
         self.receive_forever()
 
     def clock_cb(self, msg):
         if Time.from_msg(msg.clock) >= self.next_send_time:
+            self.high_rate_cb()
+            self.next_send_time = Time.from_msg(msg.clock) + Duration(seconds=1 / self.actual_rate)
+
+    def high_rate_cb(self):
+        # Gets called at actual_rate
+        self.counter += 1
+        if self.counter >= self.increase_kicking_rate:
+            # Gets called at rate
             self.send_message()
-            self.next_send_time = Time.from_msg(msg.clock) + Duration(seconds=1 / self.rate)
+            self.counter = 0
+        elif self.strategy:
+            if self.always_publish_during_kick and self.strategy.action == Strategy.ACTION_KICKING:
+                self.send_message()
+            elif self.last_action != self.strategy.action and self.strategy.action == Strategy.ACTION_KICKING:
+                self.send_message()
+            self.last_action = self.strategy.action
 
     def spin(self):
         executor = EventsExecutor()

--- a/src/bitbots_team_communication/bitbots_team_communication/bitbots_team_communication/bitbots_team_communication.py
+++ b/src/bitbots_team_communication/bitbots_team_communication/bitbots_team_communication/bitbots_team_communication.py
@@ -51,7 +51,7 @@ class TeamCommunication:
         self.socket_communication = SocketCommunication(self.node, self.logger, self.team_id, self.player_id)
 
         self.rate: int = self.node.get_parameter("rate").value
-        self.increase_kicking_rate: int = self.node.get_parameter("increase_kicking_rate").value
+        self.increase_rate_during_kick_factor: int = self.node.get_parameter("increase_rate_during_kick_factor").value
         self.always_publish_during_kick: bool = self.node.get_parameter("always_publish_during_kick").value
         self.lifetime: int = self.node.get_parameter("lifetime").value
         self.max_message_size: int = self.node.get_parameter("max_message_size").value
@@ -70,7 +70,7 @@ class TeamCommunication:
         self.run_spin_in_thread()
         self.try_to_establish_connection()
 
-        self.actual_rate = self.rate * self.increase_kicking_rate
+        self.actual_rate = self.rate * self.increase_rate_during_kick_factor
         self.counter = 0
         self.last_action = None
 
@@ -97,7 +97,7 @@ class TeamCommunication:
     def high_rate_cb(self):
         # Gets called at actual_rate
         self.counter += 1
-        if self.counter >= self.increase_kicking_rate:
+        if self.counter >= self.increase_rate_during_kick_factor:
             # Gets called at rate
             self.send_message()
             self.counter = 0

--- a/src/bitbots_team_communication/bitbots_team_communication/bitbots_team_communication/bitbots_team_communication.py
+++ b/src/bitbots_team_communication/bitbots_team_communication/bitbots_team_communication/bitbots_team_communication.py
@@ -85,7 +85,7 @@ class TeamCommunication:
             self.next_send_time = self.node.get_clock().now() + Duration(seconds=1 / self.actual_rate)
         else:
             self.node.create_timer(
-                1 / self.actual_rate, self.send_message, callback_group=MutuallyExclusiveCallbackGroup()
+                1 / self.actual_rate, self.high_rate_cb, callback_group=MutuallyExclusiveCallbackGroup()
             )
         self.receive_forever()
 

--- a/src/bitbots_team_communication/bitbots_team_communication/config/team_communication_config.yaml
+++ b/src/bitbots_team_communication/bitbots_team_communication/config/team_communication_config.yaml
@@ -20,7 +20,7 @@ team_comm:
     # Rate of published messages in Hz
     rate: 2
     # Increase rate by this factor when kicking
-    increase_kicking_rate: 10
+    increase_rate_during_kick_factor: 10
     # Always publish during kick instead of only on switch to kicking
     always_publish_during_kick: false
 

--- a/src/bitbots_team_communication/bitbots_team_communication/config/team_communication_config.yaml
+++ b/src/bitbots_team_communication/bitbots_team_communication/config/team_communication_config.yaml
@@ -19,6 +19,10 @@ team_comm:
 
     # Rate of published messages in Hz
     rate: 2
+    # Increase rate by this factor when kicking
+    increase_kicking_rate: 10
+    # Always publish during kick instead of only on switch to kicking
+    always_publish_during_kick: false
 
     # average walking speed in [m/s]
     avg_walking_speed: 0.2


### PR DESCRIPTION
# Summary
<!--- Provide a general summary of the changes -->
Parts of the behavior rely on knowing if other robots are currently missing. This information getting delayed or getting missed completly because it was less than ~0.5 seconds could be quite bad for the other teammates.


## Proposed changes
<!--- Describe your changes and why they are necessary. -->
The idea is to increase the rate at which we publish when in action kicking. The current parameters increase the check-rate twenty fold, but only actually send when changing to kicking mode. Publishing all the time during kicking would also be an option which a parameter can enabled, but this risks eating a signficant chunk of our message budget. (with current settings, we have 180 seconds left from the message budget for kicking at max rate publishing)

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce. -->

## Checklist

- [x] Run `pixi run build`
- [ ] Write documentation
- [x] Test on your machine
- [ ] Test on the robot
- [ ] Create issues for future work
- [ ] Triage this PR and label it
