### PR TITLE
Isolate vision image callback on its own executor thread

### DIFF
--- a/src/bitbots_vision/src/vision_node.cpp
+++ b/src/bitbots_vision/src/vision_node.cpp
@@ -12,6 +12,7 @@
 #include <rclcpp/experimental/executors/events_executor/events_executor.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/image.hpp>
+#include <thread>
 #include <soccer_vision_2d_msgs/msg/ball.hpp>
 #include <soccer_vision_2d_msgs/msg/ball_array.hpp>
 #include <soccer_vision_2d_msgs/msg/goalpost.hpp>
@@ -92,11 +93,26 @@ class VisionNode : public rclcpp::Node {
     debug_image_pub_ = create_publisher<sensor_msgs::msg::Image>(params_.topics.debug_image, rclcpp::QoS(1));
 
     // ---------- Image subscriber ----------
+    // Runs in its own callback group, kept off the executor that services the
+    // node's default group (parameter services included). Image processing is
+    // the slow part of this node, and if it shared a thread/executor with the
+    // parameter services, a backlog of images would starve `~/set_parameters`
+    // requests until the image stream stopped. `automatically_add_to_executor_
+    // with_node = false` keeps this group from being picked up by whichever
+    // executor later calls `add_node()`; it is instead added explicitly to a
+    // dedicated executor in `main()`.
+    image_cb_group_ = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive,
+                                             /*automatically_add_to_executor_with_node=*/false);
+    rclcpp::SubscriptionOptions image_sub_opts;
+    image_sub_opts.callback_group = image_cb_group_;
     image_sub_ = create_subscription<sensor_msgs::msg::Image>(
-        params_.topics.image, rclcpp::QoS(1), std::bind(&VisionNode::image_callback, this, std::placeholders::_1));
+        params_.topics.image, rclcpp::QoS(1), std::bind(&VisionNode::image_callback, this, std::placeholders::_1),
+        image_sub_opts);
 
     RCLCPP_INFO(get_logger(), "bitbots_vision ready");
   }
+
+  rclcpp::CallbackGroup::SharedPtr get_image_callback_group() const { return image_cb_group_; }
 
  private:
   // ---- Parameters ----
@@ -116,6 +132,7 @@ class VisionNode : public rclcpp::Node {
   rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr debug_image_pub_;
 
   // ---- Subscriber ----
+  rclcpp::CallbackGroup::SharedPtr image_cb_group_;
   rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr image_sub_;
 
   // ---- Debug image ----
@@ -333,9 +350,21 @@ int main(int argc, char** argv) {
 
   rclcpp::init(argc, argv);
   auto node = std::make_shared<bitbots_vision::VisionNode>();
+
+  // The image callback group runs on its own executor/thread so that a
+  // backlog of image processing can never starve the node's default group
+  // (parameter services, etc.) — see the comment at image_cb_group_'s
+  // creation in the constructor for details.
+  rclcpp::experimental::executors::EventsExecutor image_executor;
+  image_executor.add_callback_group(node->get_image_callback_group(), node->get_node_base_interface());
+  std::thread image_thread([&image_executor]() { image_executor.spin(); });
+
   rclcpp::experimental::executors::EventsExecutor executor;
   executor.add_node(node);
   executor.spin();
+
+  image_executor.cancel();
+  image_thread.join();
   rclcpp::shutdown();
   return 0;
 }

--- a/src/bitbots_vision/src/vision_node.cpp
+++ b/src/bitbots_vision/src/vision_node.cpp
@@ -12,7 +12,6 @@
 #include <rclcpp/experimental/executors/events_executor/events_executor.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/image.hpp>
-#include <thread>
 #include <soccer_vision_2d_msgs/msg/ball.hpp>
 #include <soccer_vision_2d_msgs/msg/ball_array.hpp>
 #include <soccer_vision_2d_msgs/msg/goalpost.hpp>
@@ -22,6 +21,7 @@
 #include <soccer_vision_attribute_msgs/msg/robot.hpp>
 #include <std_msgs/msg/header.hpp>
 #include <string>
+#include <thread>
 #include <vision_msgs/msg/bounding_box2_d.hpp>
 #include <vision_msgs/msg/point2_d.hpp>
 
@@ -102,7 +102,7 @@ class VisionNode : public rclcpp::Node {
     // executor later calls `add_node()`; it is instead added explicitly to a
     // dedicated executor in `main()`.
     image_cb_group_ = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive,
-                                             /*automatically_add_to_executor_with_node=*/false);
+                                            /*automatically_add_to_executor_with_node=*/false);
     rclcpp::SubscriptionOptions image_sub_opts;
     image_sub_opts.callback_group = image_cb_group_;
     image_sub_ = create_subscription<sensor_msgs::msg::Image>(


### PR DESCRIPTION
Parameter changes (ros2 param set) could be starved indefinitely while the vision pipeline was actively processing images: image processing and the node's parameter services shared a single-threaded executor, so a backlog of image callbacks (backed up whenever inference is slower than the incoming frame rate) prevented pending `~/set_parameters` requests from ever being serviced. Moving the image subscription into its own callback group, spun on a dedicated executor thread, keeps the parameter services responsive regardless of image processing load.

Closes #969 

## Checklist

- [x] Run `pixi run build`
- [x] Write documentation
- [x] Test on your machine
- [ ] Test on the robot
- [ ] Create issues for future work
- [x] Triage this PR and label it

Note: we need to check if vision FPS are not affected.