### PR TITLE
fix(extrinsic_calibration): move after renaming 5th robot to carrie

### DIFF
--- a/src/bitbots_misc/bitbots_extrinsic_calibration/config/carrie.yaml
+++ b/src/bitbots_misc/bitbots_extrinsic_calibration/config/carrie.yaml
@@ -1,0 +1,11 @@
+/bitbots_extrinsic_camera_calibration:
+  ros__parameters:
+    offset_x: 0.43
+    offset_y: 0.0
+    offset_z: 0.0
+
+/bitbots_extrinsic_imu_calibration:
+  ros__parameters:
+    offset_x: 0.0
+    offset_y: 0.0
+    offset_z: 0.0


### PR DESCRIPTION
## Checklist

- [x] Run `pixi run build`
- [ ] Write documentation
- [x] Test on your machine
- [x] Test on the robot
- [ ] Create issues for future work
- [ ] Triage this PR and label it
