### PR TITLE
feat(whistle): changed frequency range to be closer to what the RC26 …

### DIFF
--- a/src/bitbots_misc/bitbots_whistle_detector/config/whistle_detector_parameters.yaml
+++ b/src/bitbots_misc/bitbots_whistle_detector/config/whistle_detector_parameters.yaml
@@ -1,21 +1,21 @@
 bitbots_whistle_detector:
   whistle_energy_ratio_threshold:
     type: double
-    default_value: 0.6
+    default_value: 0.4
     description: "Ratio of whistle-band energy to total energy required to trigger detection"
     validation:
       bounds<>: [0.0, 1.0]
 
   whistle_frequency_min_hz:
     type: int
-    default_value: 2000
+    default_value: 3300
     description: "Lower bound of the whistle frequency band in Hz"
     validation:
       bounds<>: [0, 22000]
 
   whistle_frequency_max_hz:
     type: int
-    default_value: 4500
+    default_value: 3550
     description: "Upper bound of the whistle frequency band in Hz"
     validation:
       bounds<>: [0, 22000]


### PR DESCRIPTION
# Summary
Whistle detection is unreliable in the RoboCup environment with a high noise floor. Further the whistle being used during games has a set electric noise so we can check the frequency range tighter. The whistle has a concentrated frequency of ~3428Hz, measured with the phyphox app.

This change does not fix the false positives that appear from whistles on other fields.


