### PR TITLE
Disable Whistle Detection

### DIFF
--- a/src/bitbots_misc/bitbots_bringup/launch/teamplayer.launch
+++ b/src/bitbots_misc/bitbots_bringup/launch/teamplayer.launch
@@ -15,7 +15,7 @@
     <arg name="monitoring" default="false" description="Whether the system monitor and udp bridge should be started" />
     <arg name="record" default="false" description="Whether the ros bag recording should be started" />
     <arg name="tts" default="false" description="Whether to speak" />
-    <arg name="whistle_detector" default="true" description="Whether to detect whistles"/>
+    <arg name="whistle_detector" default="false" description="Whether to detect whistles"/>
     <arg unless="$(var sim)" name="fieldname" default="small_division_2026" description="Loads field settings" />
     <arg if="$(var sim)" name="fieldname" default="hsl_kid" description="Loads field settings" />
 


### PR DESCRIPTION
# Summary
<!--- Provide a general summary of the changes -->

We are having some problems with whistle detection. While the parameter tuning may have fixed this, we also want to temporarily modify kick off behavior which makes this irrelevant.

## Proposed changes
<!--- Describe your changes and why they are necessary. -->

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce. -->

## Checklist

- [ ] Run `pixi run build`
- [ ] Write documentation
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Create issues for future work
- [ ] Triage this PR and label it
