### PR TITLE
Fix/pixi cache key includes manifest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           pixi-version: v0.72.0
           cache: true
+          cache-key: pixi-${{ hashFiles('pixi.toml', 'pixi.lock') }}-
 
       - name: Build
         run: pixi run -e default build

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,6 +15,7 @@ jobs:
         with:
           pixi-version: v0.72.0
           cache: true
+          cache-key: pixi-${{ hashFiles('pixi.toml', 'pixi.lock') }}-
           environments: format
 
       - name: Run pre-commit


### PR DESCRIPTION
## Summary

- Include `pixi.toml` in the `setup-pixi` cache key for CI and pre-commit workflows.
- Prevent manifest/task-only Pixi changes from reusing stale lockfile-only caches.

## Reason

`setup-pixi` derives its default project cache key from `pixi.lock`. When `pixi.toml` changes without a lockfile change, CI can restore a cache that does not match the current workspace metadata. This can make `pixi install --locked` fail intermittently with `lock file not up-to-date with the workspace`, while reruns may pass depending on cache behavior.

## Testing

- `git diff --check main..HEAD`