### PR TITLE
build: use Ninja for workspace builds

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -22,11 +22,11 @@ format = {cmd = "sh -c 'pre-commit run --all-files --hook-stage \"${PRE_COMMIT_S
 # Use broad warnings and treat them as errors for repository code.
 # C++ also enables pedantic diagnostics. C keeps pedantic diagnostics non-fatal because ROS generators emit C code
 # that is not pedantic-clean.
-cmd = "colcon build --symlink-install --packages-skip zed_wrapper zed_components zed_msgs zed_ros2 --cmake-args -G 'Unix Makefiles' -DCMAKE_C_FLAGS='-Wall -Wextra -Werror -Wno-error=pedantic' -DCMAKE_CXX_FLAGS='-Wall -Wextra -Wpedantic -Werror' "
+cmd = "colcon build --symlink-install --packages-skip zed_wrapper zed_components zed_msgs zed_ros2 --cmake-args -G Ninja -DCMAKE_C_FLAGS='-Wall -Wextra -Werror -Wno-error=pedantic' -DCMAKE_CXX_FLAGS='-Wall -Wextra -Wpedantic -Werror' "
 description = "Builds all ROS 2 packages. Add --packages-select <package names> to build specific packages."
 
 [feature.robot.tasks.build]
-cmd = "colcon build --symlink-install --cmake-args -G 'Unix Makefiles' -DCMAKE_C_FLAGS='-Wall -Wextra -Werror -Wno-error=pedantic' -DCMAKE_CXX_FLAGS='-Wall -Wextra -Wpedantic -Werror' "
+cmd = "colcon build --symlink-install --cmake-args -G Ninja -DCMAKE_C_FLAGS='-Wall -Wextra -Werror -Wno-error=pedantic' -DCMAKE_CXX_FLAGS='-Wall -Wextra -Wpedantic -Werror' "
 description = "Builds all ROS 2 packages. Add --packages-select <package names> to build specific packages."
 
 [tasks.clean]

--- a/src/lib/domain_bridge/CMakeLists.txt
+++ b/src/lib/domain_bridge/CMakeLists.txt
@@ -74,7 +74,13 @@ add_executable(${PROJECT_NAME}_exec
 ament_target_dependencies(${PROJECT_NAME}_exec
   "rclcpp_components")
 
-set_target_properties(${PROJECT_NAME}_exec PROPERTIES OUTPUT_NAME ${PROJECT_NAME} PREFIX "")
+# Keep the executable output separate from the interface generation target.
+# Ninja requires every generated path to have a single rule.
+set_target_properties(${PROJECT_NAME}_exec PROPERTIES
+  OUTPUT_NAME ${PROJECT_NAME}
+  PREFIX ""
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/bin"
+)
 
 target_link_libraries(${PROJECT_NAME}_exec
   ${PROJECT_NAME}_lib


### PR DESCRIPTION
# Summary

Switch the default and robot CMake generator from Unix Makefiles to Ninja.

## Proposed changes

- Use the already locked Ninja dependency for default workspace builds.
- Use the same generator for robot workspace builds.

## Impact

Ninja reduces build orchestration overhead and can improve parallel scheduling without changing the compiler or generated runtime code. Existing Makefile build directories must be cleaned once before using this branch.

## Stack

This PR is based on `agent/build-benchmark-baseline` so its CI timings can be compared with the baseline PR.

## Validation

- Parsed `pixi.toml` with Python's TOML parser.
- Listed Pixi tasks successfully.
- Built `bitbots_head_mover` successfully with the Ninja generator.
- `git diff --check`
